### PR TITLE
Feature/base paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     - cd ../sample-project
     - mvn clean install
     - cd ..
-    - sh generate_docs.sh
+    - ruby generate_docs.ruby
 stages:
 - name: compile
 notifications:

--- a/generate_docs.ruby
+++ b/generate_docs.ruby
@@ -1,0 +1,6 @@
+Dir.glob("swaggen/**/*.yaml") do |filename|
+  system("redoc-cli bundle #{filename}")
+  filename = filename.sub(".yaml",".html")
+  filename = filename.split("/")[-1]
+  File.rename("redoc-static.html", filename)
+end

--- a/generate_docs.ruby
+++ b/generate_docs.ruby
@@ -1,4 +1,16 @@
-Dir.glob("swaggen/**/*.yaml") do |filename|
+Dir.mkdir('sample-project_html') unless Dir.exist?('sample-project_html')
+Dir.chdir(Dir.pwd+"/sample-project_html")
+Dir.glob("../sample-project/**/*.yaml") do |filename|
+  system("redoc-cli bundle #{filename}")
+  filename = filename.sub(".yaml",".html")
+  filename = filename.split("/")[-1]
+  File.rename("redoc-static.html", filename)
+end
+
+Dir.chdir("..")
+Dir.mkdir('swaggen_html') unless Dir.exist?('swaggen_html')
+Dir.chdir(Dir.pwd+"/swaggen_html")
+Dir.glob("../swaggen/**/*.yaml") do |filename|
   system("redoc-cli bundle #{filename}")
   filename = filename.sub(".yaml",".html")
   filename = filename.split("/")[-1]

--- a/sample-project/src/main/java/servlet/DemoEndpoint.java
+++ b/sample-project/src/main/java/servlet/DemoEndpoint.java
@@ -14,7 +14,8 @@ public class DemoEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url= "/localhost/test/post",
+		uri="/post",
+		basePath="/localhost/test",
 		method="POST",
 		title="Meeting",
 		description="Post Servlet Description",
@@ -29,7 +30,8 @@ public class DemoEndpoint {
 	}
 	
 	@SwaggerGen(
-			url= "/localhost/test/put",
+			uri= "/put",
+			basePath="/localhost/test",
 			method="PUT",
 			title="Meeting",
 			description="This is a sample PUT endpoint description to be printed in a Swagger format HTML documentation file.",
@@ -49,7 +51,8 @@ public class DemoEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url= "/localhost/test/get",
+		uri="/get",
+		basePath="/localhost/test",
 		method="GET",
 		title="Meeting",
 		description="This is a sample GET endpoint description to be printed in a Swagger format HTML documentation file.",

--- a/sample-project/src/main/java/servlet/MinimalGetEndpointTest.java
+++ b/sample-project/src/main/java/servlet/MinimalGetEndpointTest.java
@@ -12,7 +12,8 @@ public class MinimalGetEndpointTest {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/minified-endpoint",
+		uri="/minified-endpoint",
+		basePath="/base",
 		title="Minimum",
 		method="GET"
 	)

--- a/sample-project/src/main/java/servlet/MockAllMethodsEndpoint.java
+++ b/sample-project/src/main/java/servlet/MockAllMethodsEndpoint.java
@@ -13,7 +13,7 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/all/put-endpoint",
+		url="base/all/put-endpoint",
 		method="PUT",
 				title="All",
 		description="Put Servlet Description",
@@ -32,7 +32,7 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/all/put-endpoint",
+		url="base/all/put-endpoint",
 		method="POST",
 				title="All",
 		description="Post Servlet Description",
@@ -51,7 +51,7 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/all/get-endpoint",
+		url="base/all/get-endpoint",
 		method="GET",
 				title="All",
 		description="Get Servlet Description",
@@ -72,7 +72,7 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/all/delete-endpoint",
+		url="base/all/delete-endpoint",
 		method="DELETE",
 				title="All",
 		description="Delete Servlet Description",

--- a/sample-project/src/main/java/servlet/MockAllMethodsEndpoint.java
+++ b/sample-project/src/main/java/servlet/MockAllMethodsEndpoint.java
@@ -13,7 +13,8 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="base/all/put-endpoint",
+		uri="/put-endpoint",
+		basePath="/base/all",
 		method="PUT",
 				title="All",
 		description="Put Servlet Description",
@@ -32,7 +33,8 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="base/all/put-endpoint",
+		uri="/put-endpoint",
+		basePath="/base/all",
 		method="POST",
 				title="All",
 		description="Post Servlet Description",
@@ -51,7 +53,8 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="base/all/get-endpoint",
+		uri="/get-endpoint",
+		basePath="/base/all",
 		method="GET",
 				title="All",
 		description="Get Servlet Description",
@@ -72,7 +75,8 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="base/all/delete-endpoint",
+		uri="/delete-endpoint",
+		basePath="/base/all",
 		method="DELETE",
 				title="All",
 		description="Delete Servlet Description",

--- a/sample-project/src/main/java/servlet/MockPostEndpoint.java
+++ b/sample-project/src/main/java/servlet/MockPostEndpoint.java
@@ -9,7 +9,8 @@ import annotation.SwaggerGen;
 public class MockPostEndpoint {
 
 	@SwaggerGen(
-		url="/base/endpoint",
+		uri="/endpoint",
+		basePath="/base",
 		method="POST",
 				title="Post",
 		description="Serverlet Description",

--- a/sample-project/src/main/java/servlet/MockPutEndpointWithSchema.java
+++ b/sample-project/src/main/java/servlet/MockPutEndpointWithSchema.java
@@ -12,7 +12,8 @@ public class MockPutEndpointWithSchema {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/all-methods-endpoint",
+		uri="/all-methods-endpoint",
+		basePath="/base",
 		method="PUT",
 				title="Put",
 		description="Put Servlet Description",

--- a/swaggen/src/main/java/annotation/SwaggerGen.java
+++ b/swaggen/src/main/java/annotation/SwaggerGen.java
@@ -15,11 +15,11 @@ import java.lang.annotation.ElementType;
 public @interface SwaggerGen {
 
 	/**
-	 * The URL of the endpoint
+	 * The URI of the endpoint
 	 * 
 	 * @return
 	 */
-	String url();
+	String uri();
 	
 	/**
 	 * The HTTP Request Method

--- a/swaggen/src/main/java/annotation/SwaggerGen.java
+++ b/swaggen/src/main/java/annotation/SwaggerGen.java
@@ -17,56 +17,56 @@ public @interface SwaggerGen {
 	/**
 	 * The URI of the endpoint
 	 * 
-	 * @return
+	 * @return the URI
 	 */
 	String uri();
 	
 	/**
 	 * The HTTP Request Method
 	 * 
-	 * @return
+	 * @return the HTTP Request Method
 	 */
 	String method();
 	
 	/**
-	 * The description of the endpoint
+	 * The title of the endpoint
 	 * 
-	 * @return
+	 * @return the title of the endpoint
 	 */
 	String title() default "";
 	
 	/**
 	 * The description of the endpoint
 	 * 
-	 * @return
+	 * @return the description of the endpoint
 	 */
 	String description() default "";
 	
 	/**
 	 * List of headers of the form "{type} {name}={description}"
 	 * 
-	 * @return
+	 * @return the list of headers
 	 */
 	String[] headers() default {};
 	
 	/**
 	 * List of query parameters of the form "{type} {name}={description}"
 	 * 
-	 * @return
+	 * @return list of query params
 	 */
 	String[] queryParams() default {};
 	
 	/**
 	 * The name of the JSON schema file that describes the body of the request
 	 * 
-	 * @return
+	 * @return name of JSON schema file
 	 */
 	String body() default "";
 	
 	/**
 	 * A list of response codes of the form "{type} {name}={description}"
 	 * 
-	 * @return
+	 * @return list of response codes
 	 */
 	String[] responses() default {"200=OK"};
 	
@@ -74,20 +74,20 @@ public @interface SwaggerGen {
 	 * The name of the JSON schema file that describes the body of the response
 	 * corresponding to the first response code provided.
 	 * 
-	 * @return
+	 * @return name of JSON SCHEMA file describing the response body
 	 */
 	String responseBody() default "";
 	
 	/**
 	 * The scheme: HTTP or HTTPS
 	 * 
-	 * @return
+	 * @return the scheme
 	 */
 	String scheme() default "HTTP";
 
 	/**
 	 * The base path
-	 * @return
+	 * @return the base path
 	 */
 	String basePath() default "";
 }

--- a/swaggen/src/main/java/annotation/SwaggerGen.java
+++ b/swaggen/src/main/java/annotation/SwaggerGen.java
@@ -85,4 +85,9 @@ public @interface SwaggerGen {
 	 */
 	String scheme() default "HTTP";
 
+	/**
+	 * The base path
+	 * @return
+	 */
+	String basePath() default "";
 }

--- a/swaggen/src/main/java/domain/output/PathURL.java
+++ b/swaggen/src/main/java/domain/output/PathURL.java
@@ -1,0 +1,45 @@
+package domain.output;
+
+/**
+ * The path and base path of the server
+ */
+public class PathURL {
+  private String uri;
+  private String basePath;
+  private String filename;
+  public PathURL() {
+
+  }
+  public PathURL(String basePath, String uri) {
+    this.uri = uri;
+    this.basePath = basePath;
+  }
+
+  public String getURI() {
+    return this.uri;
+  }
+
+  public String getBasePath() {
+    return this.basePath;
+  }
+
+  public String getFilename() {
+    return this.filename;
+  }
+
+  public String getFullPath() {
+    return this.basePath + this.uri;
+  }
+
+  public void setURI(String uri) {
+    this.uri = uri;
+  }
+
+  public void setBasePath(String basePath) {
+    this.basePath = basePath;
+  }
+
+  public void setFilename(String filename) {
+    this.filename = filename;
+  }
+}

--- a/swaggen/src/main/java/domain/output/PathUri.java
+++ b/swaggen/src/main/java/domain/output/PathUri.java
@@ -3,14 +3,14 @@ package domain.output;
 /**
  * The path and base path of the server
  */
-public class PathURL {
+public class PathUri {
   private String uri;
   private String basePath;
   private String filename;
-  public PathURL() {
+  public PathUri() {
 
   }
-  public PathURL(String basePath, String uri) {
+  public PathUri(String basePath, String uri) {
     this.uri = uri;
     this.basePath = basePath;
   }

--- a/swaggen/src/main/java/domain/output/Swagger.java
+++ b/swaggen/src/main/java/domain/output/Swagger.java
@@ -1,12 +1,14 @@
 package domain.output;
 
 import java.util.Map;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 import domain.output.path.Endpoint;
 import enums.RequestMethod;
+import domain.output.SwaggerEndpoint;
 
 /**
  * Domain object representing an entire Swagger file.
@@ -34,13 +36,13 @@ public class Swagger {
 	/**
 	 * Top level map, mapping all endpoints by their request method and URL
 	 */
-	private Map<String, Map<RequestMethod, Endpoint>> paths;
+	private Map<String, List<SwaggerEndpoint>> paths;
 
-	public Map<String, Map<RequestMethod, Endpoint>> getPaths() {
+	public Map<String, List<SwaggerEndpoint>> getPaths() {
 		return paths;
 	}
 
-	public void setPaths(Map<String, Map<RequestMethod, Endpoint>> paths) {
+	public void setPaths(Map<String, List<SwaggerEndpoint>> paths) {
 		this.paths = paths;
 	}
 

--- a/swaggen/src/main/java/domain/output/Swagger.java
+++ b/swaggen/src/main/java/domain/output/Swagger.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import domain.output.path.Endpoint;
-import domain.output.PathURL;
+import domain.output.PathUri;
 import enums.RequestMethod;
 
 /**
@@ -54,7 +54,7 @@ public class Swagger {
 	private Map<String, Map<RequestMethod, Endpoint>> paths;
 
 	@JsonIgnore
-	private Map<PathURL, Map<RequestMethod, Endpoint>> swaggerPaths;
+	private Map<PathUri, Map<RequestMethod, Endpoint>> swaggerPaths;
 
 	public Map<String, Map<RequestMethod, Endpoint>> getPaths() {
 		return paths;
@@ -73,12 +73,12 @@ public class Swagger {
 	}
 
 	@JsonProperty
-	public Map<PathURL, Map<RequestMethod, Endpoint>> getSwaggerPaths() {
+	public Map<PathUri, Map<RequestMethod, Endpoint>> getSwaggerPaths() {
 		return swaggerPaths;
 	}
 
 	@JsonIgnore
-	public void setSwaggerPaths(Map<PathURL, Map<RequestMethod, Endpoint>> swaggerPaths) {
+	public void setSwaggerPaths(Map<PathUri, Map<RequestMethod, Endpoint>> swaggerPaths) {
 		this.swaggerPaths = swaggerPaths;
 	}
 

--- a/swaggen/src/main/java/domain/output/Swagger.java
+++ b/swaggen/src/main/java/domain/output/Swagger.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 import domain.output.path.Endpoint;
 import enums.RequestMethod;
-import domain.output.SwaggerEndpoint;
 
 /**
  * Domain object representing an entire Swagger file.
@@ -20,6 +19,16 @@ public class Swagger {
 
 	public Swagger() {
 		this.paths = new HashMap<>();
+	}
+
+	/**
+	 * copy constructor
+	 * @param swagger Swagger object
+	 */
+	public Swagger(Swagger swagger) {
+		this.info = swagger.getInfo();
+		this.setVersion(swagger.getOpenapi());
+		this.paths = swagger.getPaths();
 	}
 
 	/**

--- a/swaggen/src/main/java/domain/output/Swagger.java
+++ b/swaggen/src/main/java/domain/output/Swagger.java
@@ -5,8 +5,11 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import domain.output.path.Endpoint;
+import domain.output.PathURL;
 import enums.RequestMethod;
 
 /**
@@ -28,7 +31,6 @@ public class Swagger {
 	public Swagger(Swagger swagger) {
 		this.info = swagger.getInfo();
 		this.setVersion(swagger.getOpenapi());
-		this.paths = swagger.getPaths();
 	}
 
 	/**
@@ -51,6 +53,9 @@ public class Swagger {
 	 */
 	private Map<String, Map<RequestMethod, Endpoint>> paths;
 
+	@JsonIgnore
+	private Map<PathURL, Map<RequestMethod, Endpoint>> swaggerPaths;
+
 	public Map<String, Map<RequestMethod, Endpoint>> getPaths() {
 		return paths;
 	}
@@ -65,6 +70,16 @@ public class Swagger {
 	
 	public String getSwagger() {
 		return swagger;
+	}
+
+	@JsonProperty
+	public Map<PathURL, Map<RequestMethod, Endpoint>> getSwaggerPaths() {
+		return swaggerPaths;
+	}
+
+	@JsonIgnore
+	public void setSwaggerPaths(Map<PathURL, Map<RequestMethod, Endpoint>> swaggerPaths) {
+		this.swaggerPaths = swaggerPaths;
 	}
 
 	/**

--- a/swaggen/src/main/java/domain/output/Swagger.java
+++ b/swaggen/src/main/java/domain/output/Swagger.java
@@ -1,7 +1,7 @@
 package domain.output;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -17,6 +17,10 @@ import domain.output.SwaggerEndpoint;
  */
 @JsonInclude(Include.NON_NULL)
 public class Swagger {
+
+	public Swagger() {
+		this.paths = new HashMap<>();
+	}
 
 	/**
 	 * The OpenAPI Version
@@ -36,13 +40,13 @@ public class Swagger {
 	/**
 	 * Top level map, mapping all endpoints by their request method and URL
 	 */
-	private Map<String, List<SwaggerEndpoint>> paths;
+	private Map<String, Map<RequestMethod, Endpoint>> paths;
 
-	public Map<String, List<SwaggerEndpoint>> getPaths() {
+	public Map<String, Map<RequestMethod, Endpoint>> getPaths() {
 		return paths;
 	}
 
-	public void setPaths(Map<String, List<SwaggerEndpoint>> paths) {
+	public void setPaths(Map<String, Map<RequestMethod, Endpoint>> paths) {
 		this.paths = paths;
 	}
 

--- a/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
+++ b/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
@@ -23,7 +23,7 @@ public class SwaggerEndpoint {
     return this.endpoint.get(request);
   }
 
-  public Map<RequestMethod, Endpoint> getEndpoint() {
+  public Map<RequestMethod, Endpoint> getEndpointMap() {
     return this.endpoint;
   }
 
@@ -36,7 +36,7 @@ public class SwaggerEndpoint {
   }
 
   public void addEndpoint(SwaggerEndpoint endpoint) {
-    this.endpoint.putAll(endpoint.getEndpoint());
+    this.endpoint.putAll(endpoint.getEndpointMap());
   }
 
   /**
@@ -49,7 +49,7 @@ public class SwaggerEndpoint {
   public static Map<String, Map<RequestMethod, Endpoint>> convertToValid(Map<String, SwaggerEndpoint> paths) {
     Map <String, Map<RequestMethod, Endpoint>> newPaths = new HashMap<>();
     for (Map.Entry<String, SwaggerEndpoint> endpoints: paths.entrySet()) {
-			newPaths.put(endpoints.getKey(), endpoints.getValue().getEndpoint());
+			newPaths.put(endpoints.getKey(), endpoints.getValue().getEndpointMap());
     }	
     return newPaths;
   }

--- a/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
+++ b/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
@@ -44,7 +44,7 @@ public class SwaggerEndpoint {
    * as a swagger file.
    * 
    * @param paths The map with SwaggerEndpoints as values
-   * @return Swagger compatible map (Map<String, Map<RequestMethod,Endpoint>>)
+   * @return Swagger compatible map 
    */
   public static Map<String, Map<RequestMethod, Endpoint>> convertToValid(Map<String, SwaggerEndpoint> paths) {
     Map <String, Map<RequestMethod, Endpoint>> newPaths = new HashMap<>();

--- a/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
+++ b/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
@@ -48,9 +48,9 @@ public class SwaggerEndpoint {
    */
   public static Map<String, Map<RequestMethod, Endpoint>> convertToValid(Map<String, SwaggerEndpoint> paths) {
     Map <String, Map<RequestMethod, Endpoint>> newPaths = new HashMap<>();
-    for (Map.Entry<String, SwaggerEndpoint> endpoints: paths.entrySet()) {
-			newPaths.put(endpoints.getKey(), endpoints.getValue().getEndpointMap());
-    }	
+    for (String url: paths.keySet()) {
+      newPaths.put(url, paths.get(url).getEndpointMap());
+    }
     return newPaths;
   }
 }

--- a/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
+++ b/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
@@ -1,6 +1,8 @@
 package domain.output;
 
+import java.util.HashMap;
 import java.util.Map;
+
 
 import enums.RequestMethod;
 import domain.output.path.Endpoint;
@@ -8,23 +10,35 @@ import domain.output.path.Endpoint;
 public class SwaggerEndpoint {
   private Map<RequestMethod, Endpoint> endpoint;
 
-  public SwaggerEndpoint(Map<RequestMethod,Endpoint> endpoint){
-    this.endpoint = endpoint;
-  }
+  public SwaggerEndpoint() {
+    this.endpoint = new HashMap<>();
+  };
 
   public Endpoint getEndpoint(RequestMethod request) {
     return this.endpoint.get(request);
   }
 
-  public Map<RequestMethod, Endpoint> getEndpointMap() {
+  public Map<RequestMethod, Endpoint> getEndpoint() {
     return this.endpoint;
   }
 
-  public void setEndpointMap(Map<RequestMethod, Endpoint> EndpointMap) {
-    this.endpoint = EndpointMap;
+  public void setEndpoint(Map<RequestMethod, Endpoint> Endpoint) {
+    this.endpoint = Endpoint;
   }
 
-  public void addEndpointMap(RequestMethod request, Endpoint endpoint) {
+  public void addEndpoint(RequestMethod request, Endpoint endpoint) {
     this.endpoint.put(request, endpoint);
+  }
+
+  public void addEndpoint(SwaggerEndpoint endpoint) {
+    this.endpoint.putAll(endpoint.getEndpoint());
+  }
+
+  public static Map<String, Map<RequestMethod, Endpoint>> convertToValid(Map<String, SwaggerEndpoint> paths) {
+    Map <String, Map<RequestMethod, Endpoint>> newPaths = new HashMap<>();
+    for (Map.Entry<String, SwaggerEndpoint> endpoints: paths.entrySet()) {
+			newPaths.put(endpoints.getKey(), endpoints.getValue().getEndpoint());
+    }	
+    return newPaths;
   }
 }

--- a/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
+++ b/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
@@ -7,6 +7,11 @@ import java.util.Map;
 import enums.RequestMethod;
 import domain.output.path.Endpoint;
 
+/**
+ * Class containing a map of the request method and endpoint required
+ * to make a swagger file.
+ * 
+ */
 public class SwaggerEndpoint {
   private Map<RequestMethod, Endpoint> endpoint;
 
@@ -34,6 +39,13 @@ public class SwaggerEndpoint {
     this.endpoint.putAll(endpoint.getEndpoint());
   }
 
+  /**
+   * Extracts the map from the variable so that it will be compatible
+   * as a swagger file.
+   * 
+   * @param paths The map with SwaggerEndpoints as values
+   * @return Swagger compatible map (Map<String, Map<RequestMethod,Endpoint>>)
+   */
   public static Map<String, Map<RequestMethod, Endpoint>> convertToValid(Map<String, SwaggerEndpoint> paths) {
     Map <String, Map<RequestMethod, Endpoint>> newPaths = new HashMap<>();
     for (Map.Entry<String, SwaggerEndpoint> endpoints: paths.entrySet()) {

--- a/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
+++ b/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import enums.RequestMethod;
 import domain.output.path.Endpoint;
+import domain.output.PathURL;
 
 /**
  * Class containing a map of the request method and endpoint required
@@ -46,9 +47,9 @@ public class SwaggerEndpoint {
    * @param paths The map with SwaggerEndpoints as values
    * @return Swagger compatible map 
    */
-  public static Map<String, Map<RequestMethod, Endpoint>> convertToValid(Map<String, SwaggerEndpoint> paths) {
-    Map <String, Map<RequestMethod, Endpoint>> newPaths = new HashMap<>();
-    for (String url: paths.keySet()) {
+  public static Map<PathURL, Map<RequestMethod, Endpoint>> convertToValid(Map<PathURL, SwaggerEndpoint> paths) {
+    Map <PathURL, Map<RequestMethod, Endpoint>> newPaths = new HashMap<>();
+    for (PathURL url: paths.keySet()) {
       newPaths.put(url, paths.get(url).getEndpointMap());
     }
     return newPaths;

--- a/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
+++ b/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
@@ -2,7 +2,7 @@ package domain.output;
 
 import java.util.HashMap;
 import java.util.Map;
-
+import java.util.concurrent.ConcurrentHashMap;
 
 import enums.RequestMethod;
 import domain.output.path.Endpoint;
@@ -48,7 +48,7 @@ public class SwaggerEndpoint {
    * @return Swagger compatible map 
    */
   public static Map<PathUri, Map<RequestMethod, Endpoint>> convertToValid(Map<PathUri, SwaggerEndpoint> paths) {
-    Map <PathUri, Map<RequestMethod, Endpoint>> newPaths = new HashMap<>();
+    Map <PathUri, Map<RequestMethod, Endpoint>> newPaths = new ConcurrentHashMap<>();
     for (PathUri url: paths.keySet()) {
       newPaths.put(url, paths.get(url).getEndpointMap());
     }

--- a/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
+++ b/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import enums.RequestMethod;
 import domain.output.path.Endpoint;
-import domain.output.PathURL;
+import domain.output.PathUri;
 
 /**
  * Class containing a map of the request method and endpoint required
@@ -47,9 +47,9 @@ public class SwaggerEndpoint {
    * @param paths The map with SwaggerEndpoints as values
    * @return Swagger compatible map 
    */
-  public static Map<PathURL, Map<RequestMethod, Endpoint>> convertToValid(Map<PathURL, SwaggerEndpoint> paths) {
-    Map <PathURL, Map<RequestMethod, Endpoint>> newPaths = new HashMap<>();
-    for (PathURL url: paths.keySet()) {
+  public static Map<PathUri, Map<RequestMethod, Endpoint>> convertToValid(Map<PathUri, SwaggerEndpoint> paths) {
+    Map <PathUri, Map<RequestMethod, Endpoint>> newPaths = new HashMap<>();
+    for (PathUri url: paths.keySet()) {
       newPaths.put(url, paths.get(url).getEndpointMap());
     }
     return newPaths;

--- a/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
+++ b/swaggen/src/main/java/domain/output/SwaggerEndpoint.java
@@ -1,0 +1,30 @@
+package domain.output;
+
+import java.util.Map;
+
+import enums.RequestMethod;
+import domain.output.path.Endpoint;
+
+public class SwaggerEndpoint {
+  private Map<RequestMethod, Endpoint> endpoint;
+
+  public SwaggerEndpoint(Map<RequestMethod,Endpoint> endpoint){
+    this.endpoint = endpoint;
+  }
+
+  public Endpoint getEndpoint(RequestMethod request) {
+    return this.endpoint.get(request);
+  }
+
+  public Map<RequestMethod, Endpoint> getEndpointMap() {
+    return this.endpoint;
+  }
+
+  public void setEndpointMap(Map<RequestMethod, Endpoint> EndpointMap) {
+    this.endpoint = EndpointMap;
+  }
+
+  public void addEndpointMap(RequestMethod request, Endpoint endpoint) {
+    this.endpoint.put(request, endpoint);
+  }
+}

--- a/swaggen/src/main/java/enums/ContentType.java
+++ b/swaggen/src/main/java/enums/ContentType.java
@@ -35,7 +35,7 @@ public enum ContentType {
 	/**
 	 * Converts the ENUM to the String representation.
 	 * 
-	 * @return
+	 * @return the string representation of the ENUM
 	 */
 	@JsonValue
 	public String value() {

--- a/swaggen/src/main/java/factory/ParameterFactory.java
+++ b/swaggen/src/main/java/factory/ParameterFactory.java
@@ -39,7 +39,7 @@ public class ParameterFactory {
 		List<Parameter> parameters = new ArrayList<>();
 		parameters.addAll(getParamList(ParamLocation.HEADER, annotation.headers()));
 		parameters.addAll(getParamList(ParamLocation.QUERY, annotation.queryParams()));
-		parameters.addAll(getParamList(ParamLocation.PATH, getPathVariables(annotation.url())));
+		parameters.addAll(getParamList(ParamLocation.PATH, getPathVariables(annotation.uri())));
 		return parameters;
 	}
 	
@@ -76,19 +76,19 @@ public class ParameterFactory {
 	}
 	
 	/**
-	 * Gets an array of parameters from a URL
+	 * Gets an array of parameters from a uri
 	 * 
-	 * @param url the url
+	 * @param uri the uri
 	 * @return the list of parameters
 	 */
-	private static String[] getPathVariables(String url) {
+	private static String[] getPathVariables(String uri) {
 		List<String> paramList = new ArrayList<>();
 		int index = 0;
-		while(index < url.length() && url.indexOf(OPEN, index) != -1) {
-			int open = url.indexOf(OPEN, index);
-			int close = url.indexOf(CLOSE, open);
+		while(index < uri.length() && uri.indexOf(OPEN, index) != -1) {
+			int open = uri.indexOf(OPEN, index);
+			int close = uri.indexOf(CLOSE, open);
 			if(close != -1) {
-				String parameter = url.substring(open + 1, close);
+				String parameter = uri.substring(open + 1, close);
 				paramList.add(parameter);
 			}
 		}

--- a/swaggen/src/main/java/generator/PathGenerator.java
+++ b/swaggen/src/main/java/generator/PathGenerator.java
@@ -19,7 +19,7 @@ public class PathGenerator {
 	/**
 	 * Generates a Map of URLs and RequestMethods to Endpoints.
 	 * 
-	 * @param klasses s set of annotated classes
+	 * @param klasses list of annotated classes
 	 * @return the map
 	 */
 	public static Map<String, SwaggerEndpoint> generatePathsFromClassList(Class<?>[] klasses) {
@@ -67,18 +67,17 @@ public class PathGenerator {
 	 * @param classPaths Map of new Swagger Endpoints in the class
 	 */
 	private static void checkClassEndpoints(Map<String, SwaggerEndpoint> existingPaths, Map<String, SwaggerEndpoint> classPaths) {
-		if (!existingPaths.isEmpty()) {
-			for(Map.Entry<String, SwaggerEndpoint> pathEntry: existingPaths.entrySet()) {
-				for(Map.Entry<String, SwaggerEndpoint> classEntry: classPaths.entrySet()) {
-					if (pathEntry.getKey().equals(classEntry.getKey())) {
-						pathEntry.getValue().addEndpoint(classEntry.getValue());
-					} else {
-						existingPaths.putAll(classPaths);
-					}
-				}
+		if (existingPaths.isEmpty()) {
+			existingPaths.putAll(classPaths);
+			return;
+		}
+
+		for(String pathKey: existingPaths.keySet()) {
+			if (classPaths.containsKey(pathKey)) {
+				existingPaths.get(pathKey).addEndpoint(classPaths.get(pathKey));
+			} else {
+				existingPaths.putAll(classPaths);
 			}
-		}	else {
-		existingPaths.putAll(classPaths);
 		}
 	}
 
@@ -90,12 +89,13 @@ public class PathGenerator {
 	 * @param existingPaths Map of existing Swagger Endpoints
 	 */
 	private static void checkRequestMethods(SwaggerGen annotation, Map<String, SwaggerEndpoint> existingPaths) {
-		if(annotation != null) {
-			if (!existingPaths.containsKey(annotation.basePath() + annotation.uri())){
-				existingPaths.put(annotation.basePath() + annotation.uri(), generatePathFromAnnotation(annotation));
-			} else {
-				existingPaths.get(annotation.basePath() + annotation.uri()).addEndpoint(generatePathFromAnnotation(annotation));
-			}
+		if (annotation == null) {
+			throw new IllegalArgumentException("annotation cannot be null");
+		}
+		if (!existingPaths.containsKey(annotation.basePath() + annotation.uri())){
+			existingPaths.put(annotation.basePath() + annotation.uri(), generatePathFromAnnotation(annotation));
+		} else {
+			existingPaths.get(annotation.basePath() + annotation.uri()).addEndpoint(generatePathFromAnnotation(annotation));
 		}
 	}
 }

--- a/swaggen/src/main/java/generator/PathGenerator.java
+++ b/swaggen/src/main/java/generator/PathGenerator.java
@@ -6,7 +6,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import annotation.SwaggerGen;
 import domain.output.SwaggerEndpoint;
-import domain.output.PathURL;
+import domain.output.PathUri;
 import enums.RequestMethod;
 import factory.EndpointFactory;
 
@@ -23,10 +23,10 @@ public class PathGenerator {
 	 * @param klasses list of annotated classes
 	 * @return the map
 	 */
-	public static Map<PathURL, SwaggerEndpoint> generatePathsFromClassList(Class<?>[] klasses) {
-		Map<PathURL, SwaggerEndpoint> existingPaths = new ConcurrentHashMap<>();
+	public static Map<PathUri, SwaggerEndpoint> generatePathsFromClassList(Class<?>[] klasses) {
+		Map<PathUri, SwaggerEndpoint> existingPaths = new ConcurrentHashMap<>();
 		for(Class<?> klass : klasses) {
-			Map<PathURL, SwaggerEndpoint> classPaths = generatePathsFromClass(klass);
+			Map<PathUri, SwaggerEndpoint> classPaths = generatePathsFromClass(klass);
 			checkClassEndpoints(existingPaths, classPaths);
 		}
 		return existingPaths;
@@ -38,8 +38,8 @@ public class PathGenerator {
 	 * @param klass the annotated class
 	 * @return the map
 	 */
-	private static Map<PathURL, SwaggerEndpoint> generatePathsFromClass(Class<?> klass) {
-		Map<PathURL, SwaggerEndpoint> existingPaths = new ConcurrentHashMap<>();
+	private static Map<PathUri, SwaggerEndpoint> generatePathsFromClass(Class<?> klass) {
+		Map<PathUri, SwaggerEndpoint> existingPaths = new ConcurrentHashMap<>();
 		Method[] methods = klass.getDeclaredMethods();
 		for(Method method : methods) {
 			SwaggerGen annotation = method.getAnnotation(SwaggerGen.class);
@@ -67,17 +67,17 @@ public class PathGenerator {
 	 * @param existingPaths Map of existing Swagger Endpoints
 	 * @param classPaths Map of new Swagger Endpoints in the class
 	 */
-	private static void checkClassEndpoints(Map<PathURL, SwaggerEndpoint> existingPaths, Map<PathURL, SwaggerEndpoint> classPaths) {
+	private static void checkClassEndpoints(Map<PathUri, SwaggerEndpoint> existingPaths, Map<PathUri, SwaggerEndpoint> classPaths) {
 		if (existingPaths.isEmpty()) {
 			existingPaths.putAll(classPaths);
 			return;
 		}
 
-		for(PathURL pathKey: existingPaths.keySet()) {
-			if (classPaths.containsKey(pathKey)) {
+		for (PathUri pathKey : classPaths.keySet()) {
+			if(existingPaths.containsKey(pathKey)) {
 				existingPaths.get(pathKey).addEndpoint(classPaths.get(pathKey));
 			} else {
-				existingPaths.putAll(classPaths);
+				existingPaths.put(pathKey, classPaths.get(pathKey));
 			}
 		}
 	}
@@ -89,24 +89,16 @@ public class PathGenerator {
 	 * @param annotation SwaggerGen annotation
 	 * @param existingPaths Map of existing Swagger Endpoints
 	 */
-	private static void checkRequestMethods(SwaggerGen annotation, Map<PathURL, SwaggerEndpoint> existingPaths) {
+	private static void checkRequestMethods(SwaggerGen annotation, Map<PathUri, SwaggerEndpoint> existingPaths) {
 		if (annotation == null) {
 			throw new IllegalArgumentException("annotation cannot be null");
 		}
 		
-		PathURL pathURL = new PathURL(annotation.basePath(), annotation.uri());
-		if (!existingPaths.containsKey(pathURL)){
-			existingPaths.put(pathURL, generatePathFromAnnotation(annotation));
+		PathUri PathUri = new PathUri(annotation.basePath(), annotation.uri());
+		if (!existingPaths.containsKey(PathUri)){
+			existingPaths.put(PathUri, generatePathFromAnnotation(annotation));
 		} else {
-			existingPaths.get(pathURL).addEndpoint(generatePathFromAnnotation(annotation));
+			existingPaths.get(PathUri).addEndpoint(generatePathFromAnnotation(annotation));
 		}
-		// for (PathURL paths : existingPaths.keySet()) {
-		// 	PathURL pathURL = new PathURL(annotation.basePath(), annotation.uri());
-		// 	if (!paths.getFullPath().equals(fullPath)){
-		// 		existingPaths.put(pathURL, generatePathFromAnnotation(annotation));
-		// 	} else {
-		// 		existingPaths.get(pathURL).addEndpoint(generatePathFromAnnotation(annotation));
-		// 	}
-		// }
 	}
 }

--- a/swaggen/src/main/java/generator/PathGenerator.java
+++ b/swaggen/src/main/java/generator/PathGenerator.java
@@ -93,11 +93,18 @@ public class PathGenerator {
 			throw new IllegalArgumentException("annotation cannot be null");
 		}
 		
-		PathUri PathUri = new PathUri(annotation.basePath(), annotation.uri());
-		if (!existingPaths.containsKey(PathUri)){
-			existingPaths.put(PathUri, generatePathFromAnnotation(annotation));
-		} else {
-			existingPaths.get(PathUri).addEndpoint(generatePathFromAnnotation(annotation));
+		PathUri pathUri = new PathUri(annotation.basePath(), annotation.uri());
+
+		if (existingPaths.isEmpty()) {
+			existingPaths.put(pathUri, generatePathFromAnnotation(annotation));
+		}
+		for (PathUri existingPath: existingPaths.keySet()) {
+			if ((existingPath.getBasePath().equals(pathUri.getBasePath())) && 
+			(existingPath.getURI().equals(pathUri.getURI()))) {
+				existingPaths.get(existingPath).addEndpoint(generatePathFromAnnotation(annotation));
+			} else {
+				existingPaths.put(pathUri, generatePathFromAnnotation(annotation));
+			}
 		}
 	}
 }

--- a/swaggen/src/main/java/generator/PathGenerator.java
+++ b/swaggen/src/main/java/generator/PathGenerator.java
@@ -27,7 +27,7 @@ public class PathGenerator {
 		Map<PathUri, SwaggerEndpoint> existingPaths = new ConcurrentHashMap<>();
 		for(Class<?> klass : klasses) {
 			Map<PathUri, SwaggerEndpoint> classPaths = generatePathsFromClass(klass);
-			checkClassEndpoints(existingPaths, classPaths);
+			existingPaths = checkClassEndpoints(existingPaths, classPaths);
 		}
 		return existingPaths;
 	}
@@ -67,19 +67,18 @@ public class PathGenerator {
 	 * @param existingPaths Map of existing Swagger Endpoints
 	 * @param classPaths Map of new Swagger Endpoints in the class
 	 */
-	private static void checkClassEndpoints(Map<PathUri, SwaggerEndpoint> existingPaths, Map<PathUri, SwaggerEndpoint> classPaths) {
-		if (existingPaths.isEmpty()) {
-			existingPaths.putAll(classPaths);
-			return;
-		}
-
-		for (PathUri pathKey : classPaths.keySet()) {
-			if(existingPaths.containsKey(pathKey)) {
-				existingPaths.get(pathKey).addEndpoint(classPaths.get(pathKey));
-			} else {
-				existingPaths.put(pathKey, classPaths.get(pathKey));
+	private static Map<PathUri, SwaggerEndpoint> checkClassEndpoints(Map<PathUri, SwaggerEndpoint> existingPaths, Map<PathUri, SwaggerEndpoint> classPaths) {
+		for (PathUri existingPath: existingPaths.keySet()) {
+			for (PathUri pathKey : classPaths.keySet()) {
+				if ((existingPath.getBasePath().equals(pathKey.getBasePath())) && 
+					(existingPath.getURI().equals(pathKey.getURI()))) {
+					existingPaths.get(existingPath).addEndpoint(classPaths.get(pathKey));
+					classPaths.remove(pathKey);
+				}
 			}
 		}
+		existingPaths.putAll(classPaths);
+		return existingPaths;
 	}
 
 	/**

--- a/swaggen/src/main/java/generator/PathGenerator.java
+++ b/swaggen/src/main/java/generator/PathGenerator.java
@@ -1,9 +1,7 @@
 package generator;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import annotation.SwaggerGen;
@@ -21,11 +19,11 @@ public class PathGenerator {
 	/**
 	 * Generates a Map of URLs and RequestMethods to Endpoints.
 	 * 
-	 * @param klasses s list of annotated classes
+	 * @param klasses s set of annotated classes
 	 * @return the map
 	 */
-	public static Map<String, List<SwaggerEndpoint>> generatePathsFromClassList(Class<?>[] klasses) {
-		Map<String, List<SwaggerEndpoint>> pathMap = new HashMap<>();
+	public static Map<String, SwaggerEndpoint> generatePathsFromClassList(Class<?>[] klasses) {
+		Map<String, SwaggerEndpoint> pathMap = new HashMap<>();
 		for(Class<?> klass : klasses) {
 			pathMap.putAll(generatePathsFromClass(klass));
 		}
@@ -38,17 +36,18 @@ public class PathGenerator {
 	 * @param klass the annotated class
 	 * @return the map
 	 */
-	private static Map<String, List<SwaggerEndpoint>> generatePathsFromClass(Class<?> klass) {
-		Map<String, List<SwaggerEndpoint>> pathMap = new HashMap<>();
+	private static Map<String, SwaggerEndpoint> generatePathsFromClass(Class<?> klass) {
+		Map<String, SwaggerEndpoint> pathMap = new HashMap<>();
 		Method[] methods = klass.getDeclaredMethods();
 		for(Method method : methods) {
 			SwaggerGen annotation = method.getAnnotation(SwaggerGen.class);
 			if(annotation != null) {
 				if (!pathMap.containsKey(annotation.basePath() + annotation.uri())){
-					List<SwaggerEndpoint> empty = new ArrayList<>();
-					pathMap.put(annotation.basePath() + annotation.uri(), empty);
+					pathMap.put(annotation.basePath() + annotation.uri(), generatePathFromAnnotation(annotation));
+				} else {
+					pathMap.get(annotation.basePath() + annotation.uri()).addEndpoint(generatePathFromAnnotation(annotation));
 				}
-				pathMap.get(annotation.basePath() + annotation.uri()).add(generatePathFromAnnotation(annotation));
+				
 			}
 		}
 		return pathMap;
@@ -61,8 +60,8 @@ public class PathGenerator {
 	 * @return the path
 	 */
 	private static SwaggerEndpoint generatePathFromAnnotation(SwaggerGen annotation) {
-		SwaggerEndpoint endpoint = new SwaggerEndpoint(new HashMap<>());
-		endpoint.addEndpointMap(RequestMethod.valueOf(annotation.method()), EndpointFactory.createEndpoint(annotation));
+		SwaggerEndpoint endpoint = new SwaggerEndpoint();
+		endpoint.addEndpoint(RequestMethod.valueOf(annotation.method()), EndpointFactory.createEndpoint(annotation));
 		return endpoint;
 	}
 }

--- a/swaggen/src/main/java/generator/PathGenerator.java
+++ b/swaggen/src/main/java/generator/PathGenerator.java
@@ -27,6 +27,9 @@ public class PathGenerator {
 		for(Class<?> klass : klasses) {
 			Map<String, SwaggerEndpoint> classPaths = generatePathsFromClass(klass);
 			if (!pathMap.isEmpty()) {
+				// Checks if URL is already in the path map, and if it is, appends the swagger
+				// endpoints to the URL
+				// Case: multiple classes with the same endpoint
 				for(Map.Entry<String, SwaggerEndpoint> pathEntry: pathMap.entrySet()) {
 					for(Map.Entry<String, SwaggerEndpoint> classEntry: classPaths.entrySet()) {
 						if (pathEntry.getKey().equals(classEntry.getKey())) {
@@ -55,7 +58,14 @@ public class PathGenerator {
 		for(Method method : methods) {
 			SwaggerGen annotation = method.getAnnotation(SwaggerGen.class);
 			if(annotation != null) {
-				pathMap.put(annotation.basePath() + annotation.uri(), generatePathFromAnnotation(annotation));
+				// Checks if there are any other request methods within a class
+				// and puts it in the swagger endpoints map
+				// Case: multiple request methods within the same class
+				if (!pathMap.containsKey(annotation.basePath() + annotation.uri())){
+					pathMap.put(annotation.basePath() + annotation.uri(), generatePathFromAnnotation(annotation));
+				} else {
+					pathMap.get(annotation.basePath() + annotation.uri()).addEndpoint(generatePathFromAnnotation(annotation));
+				}
 			}
 		}
 		return pathMap;

--- a/swaggen/src/main/java/generator/PathGenerator.java
+++ b/swaggen/src/main/java/generator/PathGenerator.java
@@ -42,7 +42,7 @@ public class PathGenerator {
 		for(Method method : methods) {
 			SwaggerGen annotation = method.getAnnotation(SwaggerGen.class);
 			if(annotation != null) {
-				pathMap.put(annotation.url(), generatePathFromAnnotation(annotation));
+				pathMap.put(annotation.basePath() + annotation.url(), generatePathFromAnnotation(annotation));
 			}
 		}
 		return pathMap;

--- a/swaggen/src/main/java/generator/SwaggerGenerator.java
+++ b/swaggen/src/main/java/generator/SwaggerGenerator.java
@@ -48,17 +48,25 @@ public class SwaggerGenerator {
 		
 		swagger.setInfo(info);
 		swagger.setPaths(paths);
-		
-		File file = new File(filename);
-		file.getParentFile().mkdirs();
 
+		for(Map.Entry<String, Map<RequestMethod,Endpoint>> pathEntry: paths.entrySet()) {
+			File file = new File(pathEntry.getKey());
+			file.mkdirs();
+			for (Map.Entry<RequestMethod, Endpoint> endpointEntry: pathEntry.getValue().entrySet()) {
+				//System.out.println(endpointEntry.getValue().toString());
+			}
+			String name = "/" + pathEntry.getKey().replaceAll("/", "_") + "_test.yaml";
+			FileMapper.classToYaml(pathEntry.getKey()+ name, swagger);
+		}
+
+		/**
 		for (String path: paths.keySet()) {
-			System.out.println(path);
 			File filed = new File(path);
 			filed.mkdirs();
 		}
+		*/
+
 		
-		FileMapper.classToYaml(filename, swagger);
 		
 	}
 	

--- a/swaggen/src/main/java/generator/SwaggerGenerator.java
+++ b/swaggen/src/main/java/generator/SwaggerGenerator.java
@@ -47,6 +47,11 @@ public class SwaggerGenerator {
 		swagger.setInfo(info);
 		swagger.setPaths(SwaggerEndpoint.convertToValid(paths));
 
+		createYamlFiles(swagger);
+		
+	}
+
+	private static void createYamlFiles(Swagger swagger) throws JsonParseException, JsonMappingException, IOException {
 		for(String path: swagger.getPaths().keySet()) {
 			File file = new File(path.substring(1));
 			file.mkdirs();

--- a/swaggen/src/main/java/generator/SwaggerGenerator.java
+++ b/swaggen/src/main/java/generator/SwaggerGenerator.java
@@ -51,6 +51,12 @@ public class SwaggerGenerator {
 		
 		File file = new File(filename);
 		file.getParentFile().mkdirs();
+
+		for (String path: paths.keySet()) {
+			System.out.println(path);
+			File filed = new File(path);
+			filed.mkdirs();
+		}
 		
 		FileMapper.classToYaml(filename, swagger);
 		

--- a/swaggen/src/main/java/generator/SwaggerGenerator.java
+++ b/swaggen/src/main/java/generator/SwaggerGenerator.java
@@ -51,31 +51,20 @@ public class SwaggerGenerator {
 		
 		swagger.setInfo(info);
 		swagger.setSwaggerPaths(SwaggerEndpoint.convertToValid(paths));
-		// Map<PathUri, Map<RequestMethod, Endpoint>> path = SwaggerEndpoint.convertToValid(paths);
-		// Map<PathUri, Map<RequestMethod, Endpoint>> minifiedPath = new ConcurrentHashMap<>();
-
-		// for (PathUri originalPath: path.keySet()) {
-		// 	if (minifiedPath.isEmpty()) {
-		// 		minifiedPath.put(originalPath, path.get(originalPath));
-		// 	}
-		// 	for (PathUri minifyPath: minifiedPath.keySet()){
-		// 		if (originalPath.getFullPath().equals(minifyPath.getFullPath())) {
-		// 			minifiedPath.get(minifyPath).putAll(path.get(originalPath));
-		// 		} else {
-		// 			minifiedPath.put(originalPath, path.get(originalPath));
-		// 		}
-		// 	}
-		// }
-
-		// swagger.setSwaggerPaths(minifiedPath);
 
 		createYamlFiles(swagger);
-		
 	}
 
+	/**
+	 * Sets up a swagger object to be written to a yaml file
+	 * @param swagger Swagger object with all the paths
+	 * @throws JsonParseException JsonParseException
+	 * @throws JsonMappingException JsonMappingException
+	 * @throws IOException IOException
+	 */
 	private static void createYamlFiles(Swagger swagger) throws JsonParseException, JsonMappingException, IOException {
 		for(PathUri path: swagger.getSwaggerPaths().keySet()) {
-			File file = new File(path.getFullPath().substring(1));
+			File file = new File("swagger/" + path.getFullPath().substring(1));
 			file.mkdirs();
 			// yaml file's name will be the base path and the class name
 			String name = "/" + path.getFullPath().substring(1).replaceAll("/", "_") + "-test.yaml";
@@ -88,5 +77,4 @@ public class SwaggerGenerator {
 			FileMapper.classToYaml(path.getFilename(), toYaml);
 		}
 	}
-	
 }

--- a/swaggen/src/main/java/generator/SwaggerGenerator.java
+++ b/swaggen/src/main/java/generator/SwaggerGenerator.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -50,6 +51,23 @@ public class SwaggerGenerator {
 		
 		swagger.setInfo(info);
 		swagger.setSwaggerPaths(SwaggerEndpoint.convertToValid(paths));
+		// Map<PathUri, Map<RequestMethod, Endpoint>> path = SwaggerEndpoint.convertToValid(paths);
+		// Map<PathUri, Map<RequestMethod, Endpoint>> minifiedPath = new ConcurrentHashMap<>();
+
+		// for (PathUri originalPath: path.keySet()) {
+		// 	if (minifiedPath.isEmpty()) {
+		// 		minifiedPath.put(originalPath, path.get(originalPath));
+		// 	}
+		// 	for (PathUri minifyPath: minifiedPath.keySet()){
+		// 		if (originalPath.getFullPath().equals(minifyPath.getFullPath())) {
+		// 			minifiedPath.get(minifyPath).putAll(path.get(originalPath));
+		// 		} else {
+		// 			minifiedPath.put(originalPath, path.get(originalPath));
+		// 		}
+		// 	}
+		// }
+
+		// swagger.setSwaggerPaths(minifiedPath);
 
 		createYamlFiles(swagger);
 		

--- a/swaggen/src/main/java/generator/SwaggerGenerator.java
+++ b/swaggen/src/main/java/generator/SwaggerGenerator.java
@@ -2,6 +2,7 @@ package generator;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.plugin.logging.Log;
@@ -10,6 +11,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
 import domain.output.Swagger;
+import domain.output.SwaggerEndpoint;
 import domain.output.SwaggerInfo;
 import domain.output.path.Endpoint;
 import enums.RequestMethod;
@@ -35,7 +37,7 @@ public class SwaggerGenerator {
 	public static void generateSwaggerFile(Class<?>[] klasses, String filename) throws JsonParseException, JsonMappingException, IOException {
 		
 		// Create Paths
-		Map<String, Map<RequestMethod, Endpoint>> paths = generator.PathGenerator.generatePathsFromClassList(klasses);
+		Map<String, List<SwaggerEndpoint>> paths = generator.PathGenerator.generatePathsFromClassList(klasses);
 
 		Swagger swagger = new Swagger();
 		swagger.setVersion("3.0.0");
@@ -49,14 +51,11 @@ public class SwaggerGenerator {
 		swagger.setInfo(info);
 		swagger.setPaths(paths);
 
-		for(Map.Entry<String, Map<RequestMethod,Endpoint>> pathEntry: paths.entrySet()) {
-			File file = new File(pathEntry.getKey());
+		for(String path: paths.keySet()) {
+			File file = new File(path);
 			file.mkdirs();
-			for (Map.Entry<RequestMethod, Endpoint> endpointEntry: pathEntry.getValue().entrySet()) {
-				//System.out.println(endpointEntry.getValue().toString());
-			}
-			String name = "/" + pathEntry.getKey().replaceAll("/", "_") + "_test.yaml";
-			FileMapper.classToYaml(pathEntry.getKey()+ name, swagger);
+			String name = "/" + path.replaceAll("/", "_") + "_test.yaml";
+			FileMapper.classToYaml(path + name, swagger);
 		}
 
 		/**

--- a/swaggen/src/main/java/generator/SwaggerGenerator.java
+++ b/swaggen/src/main/java/generator/SwaggerGenerator.java
@@ -50,7 +50,7 @@ public class SwaggerGenerator {
 		for(String path: swagger.getPaths().keySet()) {
 			File file = new File(path.substring(1));
 			file.mkdirs();
-
+			// yaml file's name will be the base path and the class name
 			String name = "/" + path.substring(1).replaceAll("/", "_") + "-test.yaml";
 			FileMapper.classToYaml((path + name).substring(1), swagger);
 		}

--- a/swaggen/src/main/java/generator/SwaggerGenerator.java
+++ b/swaggen/src/main/java/generator/SwaggerGenerator.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import domain.output.Swagger;
 import domain.output.SwaggerEndpoint;
 import domain.output.SwaggerInfo;
-import domain.output.PathURL;
+import domain.output.PathUri;
 import enums.RequestMethod;
 import domain.output.path.Endpoint;
 import utils.io.FileMapper;
@@ -37,7 +37,7 @@ public class SwaggerGenerator {
 	public static void generateSwaggerFile(Class<?>[] klasses) throws JsonParseException, JsonMappingException, IOException {
 		
 		// Create Paths
-		Map<PathURL, SwaggerEndpoint> paths = generator.PathGenerator.generatePathsFromClassList(klasses);
+		Map<PathUri, SwaggerEndpoint> paths = generator.PathGenerator.generatePathsFromClassList(klasses);
 
 		Swagger swagger = new Swagger();
 		swagger.setVersion("3.0.0");
@@ -56,7 +56,7 @@ public class SwaggerGenerator {
 	}
 
 	private static void createYamlFiles(Swagger swagger) throws JsonParseException, JsonMappingException, IOException {
-		for(PathURL path: swagger.getSwaggerPaths().keySet()) {
+		for(PathUri path: swagger.getSwaggerPaths().keySet()) {
 			File file = new File(path.getFullPath().substring(1));
 			file.mkdirs();
 			// yaml file's name will be the base path and the class name

--- a/swaggen/src/main/java/generator/SwaggerGenerator.java
+++ b/swaggen/src/main/java/generator/SwaggerGenerator.java
@@ -4,16 +4,12 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.maven.plugin.logging.Log;
-
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
 import domain.output.Swagger;
 import domain.output.SwaggerEndpoint;
 import domain.output.SwaggerInfo;
-import domain.output.path.Endpoint;
-import enums.RequestMethod;
 import utils.io.FileMapper;
 
 /**
@@ -51,11 +47,11 @@ public class SwaggerGenerator {
 		swagger.setInfo(info);
 		swagger.setPaths(SwaggerEndpoint.convertToValid(paths));
 
-		for(String path: paths.keySet()) {
+		for(String path: swagger.getPaths().keySet()) {
 			File file = new File(path.substring(1));
 			file.mkdirs();
 
-			String name = "/" + path.substring(1).replaceAll("/", "_") + "_test.yaml";
+			String name = "/" + path.substring(1).replaceAll("/", "_") + "-test.yaml";
 			FileMapper.classToYaml((path + name).substring(1), swagger);
 		}
 	}

--- a/swaggen/src/main/java/generator/SwaggerGenerator.java
+++ b/swaggen/src/main/java/generator/SwaggerGenerator.java
@@ -2,7 +2,6 @@ package generator;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.plugin.logging.Log;
@@ -30,14 +29,15 @@ public class SwaggerGenerator {
 	 * generate a list of associated paths and POJO
 	 * 
 	 * @param klasses an array of classes that contain methods annotated with SwaggerGen
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws IOException
+	 * 
+	 * @throws JsonParseException JsonParseException
+	 * @throws JsonMappingException JsonMappingException
+	 * @throws IOException IOException
 	 **/
-	public static void generateSwaggerFile(Class<?>[] klasses, String filename) throws JsonParseException, JsonMappingException, IOException {
+	public static void generateSwaggerFile(Class<?>[] klasses) throws JsonParseException, JsonMappingException, IOException {
 		
 		// Create Paths
-		Map<String, List<SwaggerEndpoint>> paths = generator.PathGenerator.generatePathsFromClassList(klasses);
+		Map<String, SwaggerEndpoint> paths = generator.PathGenerator.generatePathsFromClassList(klasses);
 
 		Swagger swagger = new Swagger();
 		swagger.setVersion("3.0.0");
@@ -49,24 +49,15 @@ public class SwaggerGenerator {
 		info.setVersion("0.0");
 		
 		swagger.setInfo(info);
-		swagger.setPaths(paths);
+		swagger.setPaths(SwaggerEndpoint.convertToValid(paths));
 
 		for(String path: paths.keySet()) {
-			File file = new File(path);
+			File file = new File(path.substring(1));
 			file.mkdirs();
-			String name = "/" + path.replaceAll("/", "_") + "_test.yaml";
-			FileMapper.classToYaml(path + name, swagger);
-		}
 
-		/**
-		for (String path: paths.keySet()) {
-			File filed = new File(path);
-			filed.mkdirs();
+			String name = "/" + path.substring(1).replaceAll("/", "_") + "_test.yaml";
+			FileMapper.classToYaml((path + name).substring(1), swagger);
 		}
-		*/
-
-		
-		
 	}
 	
 }

--- a/swaggen/src/main/java/mojo/AnnotationReaderMojo.java
+++ b/swaggen/src/main/java/mojo/AnnotationReaderMojo.java
@@ -50,11 +50,6 @@ public class AnnotationReaderMojo extends AbstractMojo {
 
 			getLog().info("-- OBTAINING ANNOTATIONS --");
 			Class<?>[] klasses = getClassArray();
-			getLog().info("????");
-			for (Class<?> klass: klasses) {
-				getLog().info(klass.toString());
-				getLog().info("!!!");
-			}
 			getLog().info("-- PROCESSING ANNOTATIONS --");
 			
 			generator.SwaggerGenerator.generateSwaggerFile(klasses);

--- a/swaggen/src/main/java/mojo/AnnotationReaderMojo.java
+++ b/swaggen/src/main/java/mojo/AnnotationReaderMojo.java
@@ -50,7 +50,11 @@ public class AnnotationReaderMojo extends AbstractMojo {
 
 			getLog().info("-- OBTAINING ANNOTATIONS --");
 			Class<?>[] klasses = getClassArray();
-
+			getLog().info("????");
+			for (Class<?> klass: klasses) {
+				getLog().info(klass.toString());
+				getLog().info("!!!");
+			}
 			getLog().info("-- PROCESSING ANNOTATIONS --");
 			
 			generator.SwaggerGenerator.generateSwaggerFile(klasses);

--- a/swaggen/src/main/java/mojo/AnnotationReaderMojo.java
+++ b/swaggen/src/main/java/mojo/AnnotationReaderMojo.java
@@ -76,8 +76,9 @@ public class AnnotationReaderMojo extends AbstractMojo {
 		Reflections loadedKlasses = new Reflections(
 				new ConfigurationBuilder().addUrls(ClasspathHelper.forClassLoader(getClassLoader()))
 						.setScanners(new SubTypesScanner(false), new MethodAnnotationsScanner()));
-
+		getLog().info("Reflections instantiated");
 		Set<Method> swaggenMethods = loadedKlasses.getMethodsAnnotatedWith(SwaggerGen.class);
+		getLog().info("Swaggen Methods instatiated");
 		Set<Class<?>> klasses = new HashSet<Class<?>>();
 		for (Method method : swaggenMethods) {
 				klasses.add(method.getDeclaringClass());
@@ -99,10 +100,12 @@ public class AnnotationReaderMojo extends AbstractMojo {
 	private ClassLoader getClassLoader() throws DependencyResolutionRequiredException, MalformedURLException {
 		Set<URL> urls = new HashSet<>();
 		List<String> elements = project.getRuntimeClasspathElements();
+		getLog().info("Printing elements");
 		for (String element : elements) {
 			urls.add(new File(element).toURI().toURL());
+			getLog().info(element);
 		}
-
+		getLog().info("End of class path elements");
 		ClassLoader contextClassLoader = URLClassLoader.newInstance(urls.toArray(new URL[0]),
 				Thread.currentThread().getContextClassLoader());
 

--- a/swaggen/src/main/java/mojo/AnnotationReaderMojo.java
+++ b/swaggen/src/main/java/mojo/AnnotationReaderMojo.java
@@ -89,6 +89,22 @@ public class AnnotationReaderMojo extends AbstractMojo {
 	}
 
 	/**
+	 * Uses reflections to obtain the methods that have the SwaggerGen annotation in
+	 * the importing Maven project.
+	 * 
+	 * @return array of classes that contain methods annotated with SwaggerGen
+	 * @throws DependencyResolutionRequiredException if mojo is misconfigured
+	 * @throws MalformedURLException
+	 */
+	private Method[] getMethodArray() throws MalformedURLException, DependencyResolutionRequiredException {
+		Reflections loadedMethods = new Reflections(
+			new ConfigurationBuilder().addUrls(ClasspathHelper.forClassLoader(getClassLoader()))
+					.setScanners(new SubTypesScanner(false), new MethodAnnotationsScanner()));
+		Set<Method> swaggenMethods = loadedMethods.getMethodsAnnotatedWith(SwaggerGen.class);
+		return swaggenMethods.toArray(new Method[swaggenMethods.size()]);
+	}
+
+	/**
 	 * Gets the classloader for the maven project and loads it into the current
 	 * thread.
 	 * 

--- a/swaggen/src/main/java/mojo/AnnotationReaderMojo.java
+++ b/swaggen/src/main/java/mojo/AnnotationReaderMojo.java
@@ -53,7 +53,7 @@ public class AnnotationReaderMojo extends AbstractMojo {
 
 			getLog().info("-- PROCESSING ANNOTATIONS --");
 			
-			generator.SwaggerGenerator.generateSwaggerFile(klasses, "generated/swagger/sample.yaml");
+			generator.SwaggerGenerator.generateSwaggerFile(klasses);
 
 		} catch (Exception e) {
 			// Can add other catches here for more complete error handling
@@ -86,22 +86,6 @@ public class AnnotationReaderMojo extends AbstractMojo {
 		}
 
 		return klasses.toArray(new Class<?>[klasses.size()]);
-	}
-
-	/**
-	 * Uses reflections to obtain the methods that have the SwaggerGen annotation in
-	 * the importing Maven project.
-	 * 
-	 * @return array of classes that contain methods annotated with SwaggerGen
-	 * @throws DependencyResolutionRequiredException if mojo is misconfigured
-	 * @throws MalformedURLException
-	 */
-	private Method[] getMethodArray() throws MalformedURLException, DependencyResolutionRequiredException {
-		Reflections loadedMethods = new Reflections(
-			new ConfigurationBuilder().addUrls(ClasspathHelper.forClassLoader(getClassLoader()))
-					.setScanners(new SubTypesScanner(false), new MethodAnnotationsScanner()));
-		Set<Method> swaggenMethods = loadedMethods.getMethodsAnnotatedWith(SwaggerGen.class);
-		return swaggenMethods.toArray(new Method[swaggenMethods.size()]);
 	}
 
 	/**

--- a/swaggen/src/main/java/utils/io/FileMapper.java
+++ b/swaggen/src/main/java/utils/io/FileMapper.java
@@ -3,6 +3,8 @@ package utils.io;
 import java.io.File;
 import java.io.IOException;
 
+import domain.output.Swagger;
+import domain.output.SwaggerEndpoint;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -21,10 +23,12 @@ public class FileMapper {
 	 * 
 	 * @param filename the name of the JSON file
 	 * @param klass    the class the represents the JSON structure
+	 * @param <T>      The type
+	 * 
 	 * @return the object that the JSON mapped to
-	 * @throws JsonParseException
-	 * @throws JsonMappingException
-	 * @throws IOException
+	 * @throws JsonParseException JsonParseException
+	 * @throws JsonMappingException JsonMappingException
+	 * @throws IOException IOException
 	 */
 	public static <T> T jsonToClass(String filename, Class<T> klass)
 			throws JsonParseException, JsonMappingException, IOException {
@@ -37,15 +41,29 @@ public class FileMapper {
 	 * Maps a Java object to a YAML file.
 	 * 
 	 * @param filename the name of the YAML file
-	 * @param object the Java object
-	 * @throws JsonGenerationException
-	 * @throws JsonMappingException
-	 * @throws IOException
+	 * @param newSwagger the Java object, typically swagger object 
+	 * @param <T> The type
+	 * 
+	 * @throws JsonParseException JsonParseException
+	 * @throws JsonMappingException JsonMappingException
+	 * @throws IOException IOException
 	 */
-	public static <T> void classToYaml(String filename, T object)
+	public static <T> void classToYaml(String filename, T newSwagger)
 			throws JsonGenerationException, JsonMappingException, IOException {
 		ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
-		objectMapper.writeValue(new File(filename), object);
+		File file = new File(filename);
+
+		if (file.exists()) {
+			Swagger existingSwagger = objectMapper.readValue(file, Swagger.class);
+			for (String newURL: ((Swagger)newSwagger).getPaths().keySet()) {
+				for (String oldURL: existingSwagger.getPaths().keySet()) {
+					if (newURL.equals(oldURL)) {
+						((Swagger)newSwagger).getPaths().get(newURL).putAll(existingSwagger.getPaths().get(oldURL));
+					}
+				}
+			}
+		}
+		objectMapper.writeValue(file, newSwagger);
 	}
 
 }

--- a/swaggen/src/main/java/utils/io/FileMapper.java
+++ b/swaggen/src/main/java/utils/io/FileMapper.java
@@ -89,11 +89,9 @@ public class FileMapper {
 			return;
 		}
 		Swagger existingSwagger = objectMapper.readValue(file, Swagger.class);
-		for (String newURL: swagger.getPaths().keySet()) {
-			for (String oldURL: existingSwagger.getPaths().keySet()) {
-				if (existingSwagger.getPaths().containsKey(newURL)) {
-					swagger.getPaths().get(newURL).putAll(existingSwagger.getPaths().get(oldURL));
-				}
+		for (String Uri: existingSwagger.getPaths().keySet()) {
+			if(swagger.getPaths().containsKey(Uri)) {
+				swagger.getPaths().get(Uri).putAll(existingSwagger.getPaths().get(Uri));
 			}
 		}
 	}

--- a/swaggen/src/main/java/utils/io/FileMapper.java
+++ b/swaggen/src/main/java/utils/io/FileMapper.java
@@ -67,32 +67,8 @@ public class FileMapper {
 	public static void classToYaml(String path, Swagger newSwagger)
 		throws JsonGenerationException, JsonMappingException, IOException {
 		ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
-		File file = new File(path.substring(1));
-
-		checkExistingEndpoints(newSwagger, file, objectMapper);
+		File file = new File("swagger/" + path);
+		
 		objectMapper.writeValue(file, newSwagger);
-	}
-
-	/**
-	 * Checks for existing endpoints in yaml files and if matched, add the existing
-	 * request methods to the new Swagger file.
-	 * @param swagger the swagger object containing all the endpoints
-	 * @param file file object, containing where it is supposed to be placed
-	 * @param objectMapper the ObjectMapper
-	 * @throws JsonGenerationException
-	 * @throws JsonMappingException
-	 * @throws IOException
-	 */
-	private static void checkExistingEndpoints(Swagger swagger, File file, ObjectMapper objectMapper) 
-		throws JsonGenerationException, JsonMappingException, IOException {
-		if(!file.exists()) {
-			return;
-		}
-		Swagger existingSwagger = objectMapper.readValue(file, Swagger.class);
-		for (String Uri: existingSwagger.getPaths().keySet()) {
-			if(swagger.getPaths().containsKey(Uri)) {
-				swagger.getPaths().get(Uri).putAll(existingSwagger.getPaths().get(Uri));
-			}
-		}
 	}
 }

--- a/swaggen/src/main/java/utils/io/FileMapper.java
+++ b/swaggen/src/main/java/utils/io/FileMapper.java
@@ -58,7 +58,8 @@ public class FileMapper {
 			throws JsonGenerationException, JsonMappingException, IOException {
 		ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
 		File file = new File(filename);
-		// Check for existing endpoints in yaml file
+
+		// Check for existing endpoints in yaml file and add request methods to the new one
 		if (file.exists() && newSwagger instanceof Swagger) {
 			Swagger existingSwagger = objectMapper.readValue(file, Swagger.class);
 			for (String newURL: ((Swagger)newSwagger).getPaths().keySet()) {
@@ -70,13 +71,14 @@ public class FileMapper {
 			}
 		}
 
-		// Discard any endpoints from the given swagger that don't belong in the file
+		// Discard any different endpoints from the given swagger that don't belong in the file
 		if (newSwagger instanceof Swagger) {
 			for (Map.Entry<String, Map<RequestMethod, Endpoint>> path: ((Swagger)newSwagger).getPaths().entrySet()) {
-				String key = path.getKey();
+				String url = path.getKey();
 				int basePathIndex = filename.lastIndexOf("/");
 				String basePath = "/" + filename.substring(0, basePathIndex);
-				if (key.equals(basePath)) {
+
+				if (url.equals(basePath)) {
 					Swagger toYaml = new Swagger();
 					toYaml.setInfo(((Swagger)newSwagger).getInfo());
 					toYaml.setVersion(((Swagger)newSwagger).getOpenapi());

--- a/swaggen/src/main/java/utils/io/FileMapper.java
+++ b/swaggen/src/main/java/utils/io/FileMapper.java
@@ -3,13 +3,7 @@ package utils.io;
 import java.io.File;
 import java.io.IOException;
 
-import java.util.Map;
-import java.util.HashMap;
-
-
 import domain.output.Swagger;
-import enums.RequestMethod;
-import domain.output.path.Endpoint;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonParseException;
@@ -63,28 +57,26 @@ public class FileMapper {
 	/**
 	 * Maps a Swagger object to a YAML file.
 	 * 
-	 * @param filename the name of the YAML file
+	 * @param path The file path of the swagger file
 	 * @param newSwagger the Swagger
 	 * 
 	 * @throws JsonGenerationException JsonGenerationException
 	 * @throws JsonMappingException JsonMappingException
 	 * @throws IOException IOException
 	 */
-	public static void classToYaml(String filename, Swagger newSwagger)
+	public static void classToYaml(String path, Swagger newSwagger)
 		throws JsonGenerationException, JsonMappingException, IOException {
 		ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
-		File file = new File(filename);
+		File file = new File(path.substring(1));
 
 		checkExistingEndpoints(newSwagger, file, objectMapper);
-
-		Swagger toYaml = convertSwagger(newSwagger, filename, file, objectMapper);
-		objectMapper.writeValue(file, toYaml);
+		objectMapper.writeValue(file, newSwagger);
 	}
 
 	/**
 	 * Checks for existing endpoints in yaml files and if matched, add the existing
 	 * request methods to the new Swagger file.
-	 * @param swagger the swagger object containing all the endpoitns
+	 * @param swagger the swagger object containing all the endpoints
 	 * @param file file object, containing where it is supposed to be placed
 	 * @param objectMapper the ObjectMapper
 	 * @throws JsonGenerationException
@@ -104,34 +96,5 @@ public class FileMapper {
 				}
 			}
 		}
-	}
-
-
-	/**
-	 * Finds the correct request method and endpoint within the swagger map given the filename, and writes
-	 * it to a yaml file
-	 * @param swagger the swagger object containing all the endpoints
-	 * @param filename name of the file
-	 * @param file file object, containing where it is supposed to be placed
-	 * @param objectMapper the ObjectMapper
-	 * @throws JsonGenerationException
-	 * @throws JsonMappingException
-	 * @throws IOException
-	 */
-	private static Swagger convertSwagger(Swagger swagger, String filename, File file, ObjectMapper objectMapper)
-		throws JsonGenerationException, JsonMappingException, IOException {
-		for (String url: swagger.getPaths().keySet()) {
-			int basePathIndex = filename.lastIndexOf("/");
-			String basePath = "/" + filename.substring(0, basePathIndex);
-
-			if (url.equals(basePath)) {
-				Swagger toYaml = new Swagger(swagger);
-				Map<String, Map<RequestMethod, Endpoint>> exactEndpoint = new HashMap<>();
-				exactEndpoint.put(url, swagger.getPaths().get(url));
-				toYaml.setPaths(exactEndpoint);
-				return toYaml;
-			}
-		}
-		return new Swagger();
 	}
 }

--- a/swaggen/src/main/java/utils/stringparsing/ParameterParser.java
+++ b/swaggen/src/main/java/utils/stringparsing/ParameterParser.java
@@ -93,8 +93,8 @@ public class ParameterParser implements StringParser<ParsedParameter> {
 	 * Constructs a parser with the given delimiters. Will parse
 	 * a String with the format "type{typeDelimiter}name{descriptionDelimiter}description"
 	 * 
-	 * @param typeDelimiter
-	 * @param descriptionDelimiter
+	 * @param typeDelimiter The type delimiter
+	 * @param descriptionDelimiter The description delimiter
 	 */
 	public ParameterParser(String typeDelimiter, String descriptionDelimiter) {
 		fullParameter = Pattern.compile(TYPE+typeDelimiter+NAME+descriptionDelimiter+DESCRIPTION);

--- a/swaggen/src/main/java/utils/stringparsing/StringParser.java
+++ b/swaggen/src/main/java/utils/stringparsing/StringParser.java
@@ -14,7 +14,7 @@ public interface StringParser<T> {
 	 * 
 	 * @param s the string
 	 * @return the object
-	 * @throws ParseException 
+	 * @throws ParseException ParseException
 	 */
 	public T parse(String s) throws ParseException;
 

--- a/swaggen/src/test/java/mock/endpoint/MinimalGetEndpointTest.java
+++ b/swaggen/src/test/java/mock/endpoint/MinimalGetEndpointTest.java
@@ -12,7 +12,7 @@ public class MinimalGetEndpointTest {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/minified-endpoint",
+		uri="/minified-endpoint",
 		basePath="base",
 		method="GET"
 	)

--- a/swaggen/src/test/java/mock/endpoint/MinimalGetEndpointTest.java
+++ b/swaggen/src/test/java/mock/endpoint/MinimalGetEndpointTest.java
@@ -12,7 +12,8 @@ public class MinimalGetEndpointTest {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/minified-endpoint",
+		url="/minified-endpoint",
+		basePath="base",
 		method="GET"
 	)
 	public void doGet(Object request, Object resp) {

--- a/swaggen/src/test/java/mock/endpoint/MinimalGetEndpointTest.java
+++ b/swaggen/src/test/java/mock/endpoint/MinimalGetEndpointTest.java
@@ -13,7 +13,7 @@ public class MinimalGetEndpointTest {
 	 */
 	@SwaggerGen(
 		uri="/minified-endpoint",
-		basePath="base",
+		basePath="/base",
 		method="GET"
 	)
 	public void doGet(Object request, Object resp) {

--- a/swaggen/src/test/java/mock/endpoint/MockAllMethodsEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockAllMethodsEndpoint.java
@@ -13,7 +13,8 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/all/put-endpoint",
+		url="/put-endpoint",
+		basePath="base/all",
 		method="PUT",
 		description="Put Servlet Description",
 		headers={"Content-Type=application/json", "langHeader=en"},
@@ -31,7 +32,8 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/all/put-endpoint",
+		url="/put-endpoint",
+		basePath="base/all",
 		method="POST",
 		description="Post Servlet Description",
 		headers={"Content-Type=application/json", "langHeader=en"},
@@ -49,7 +51,8 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/all/get-endpoint",
+		url="/get-endpoint",
+		basePath="base/all",
 		method="GET",
 		description="Get Servlet Description",
 		headers={"Content-Type=application/json", "langHeader=en"},
@@ -69,7 +72,8 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/all/delete-endpoint",
+		url="/delete-endpoint",
+		basePath="base/all",
 		method="DELETE",
 		description="Delete Servlet Description",
 		headers={"Content-Type=application/json", "langHeader=en"},

--- a/swaggen/src/test/java/mock/endpoint/MockAllMethodsEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockAllMethodsEndpoint.java
@@ -13,7 +13,7 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/put-endpoint",
+		uri="/endpoint",
 		basePath="base/all",
 		method="PUT",
 		description="Put Servlet Description",
@@ -32,7 +32,7 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/put-endpoint",
+		uri="/endpoint",
 		basePath="base/all",
 		method="POST",
 		description="Post Servlet Description",
@@ -51,7 +51,7 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/get-endpoint",
+		uri="/endpoint",
 		basePath="base/all",
 		method="GET",
 		description="Get Servlet Description",
@@ -72,7 +72,7 @@ public class MockAllMethodsEndpoint {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/delete-endpoint",
+		uri="/endpoint",
 		basePath="base/all",
 		method="DELETE",
 		description="Delete Servlet Description",

--- a/swaggen/src/test/java/mock/endpoint/MockAllMethodsEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockAllMethodsEndpoint.java
@@ -14,7 +14,7 @@ public class MockAllMethodsEndpoint {
 	 */
 	@SwaggerGen(
 		uri="/endpoint",
-		basePath="base/all",
+		basePath="/base/all",
 		method="PUT",
 		description="Put Servlet Description",
 		headers={"Content-Type=application/json", "langHeader=en"},
@@ -33,7 +33,7 @@ public class MockAllMethodsEndpoint {
 	 */
 	@SwaggerGen(
 		uri="/endpoint",
-		basePath="base/all",
+		basePath="/base/all",
 		method="POST",
 		description="Post Servlet Description",
 		headers={"Content-Type=application/json", "langHeader=en"},
@@ -52,7 +52,7 @@ public class MockAllMethodsEndpoint {
 	 */
 	@SwaggerGen(
 		uri="/endpoint",
-		basePath="base/all",
+		basePath="/base/all",
 		method="GET",
 		description="Get Servlet Description",
 		headers={"Content-Type=application/json", "langHeader=en"},
@@ -73,7 +73,7 @@ public class MockAllMethodsEndpoint {
 	 */
 	@SwaggerGen(
 		uri="/endpoint",
-		basePath="base/all",
+		basePath="/base/all",
 		method="DELETE",
 		description="Delete Servlet Description",
 		headers={"Content-Type=application/json", "langHeader=en"},

--- a/swaggen/src/test/java/mock/endpoint/MockGetPostEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockGetPostEndpoint.java
@@ -1,0 +1,43 @@
+package mock.endpoint;
+import annotation.SwaggerGen;
+import mock.service.MockSlingServerletRequest;
+import mock.service.MockSlingServerletResponse;
+
+/**
+ * A Fake endpoint for testing.
+ */
+public class MockGetPostEndpoint {
+
+	@SwaggerGen(
+		uri="/combined",
+		basePath="/base/all",
+		method="POST",
+		title="Post Serverlet Title",
+		description="Post Serverlet Description",
+		headers={"Content-Type=application/json"},
+		queryParams={
+				"i param = An Integer Param", 
+				"b param2 = A Boolean Param", 
+				"s64 param3 = A String Param",
+				"param4 = Another String Param"
+				},
+		body="body.scheme",
+		responses={"200=OK", "400=Bad Request", "404"},
+		responseBody= "response.scheme",
+		scheme="HTTP"
+	)
+	protected static final void doPost(MockSlingServerletRequest request, MockSlingServerletResponse resp) {
+		// Implementation not important.
+  }
+  
+  @SwaggerGen(
+		uri="/combined",
+		basePath="/base/all",
+		method="GET",
+		title="Get Serverlet Title",
+		description="Get Serverlet Description"
+	)
+	protected static final void doGet(MockSlingServerletRequest request, MockSlingServerletResponse resp) {
+		// Implementation not important.
+  }
+}

--- a/swaggen/src/test/java/mock/endpoint/MockMinimalGetEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockMinimalGetEndpoint.java
@@ -5,7 +5,7 @@ import annotation.SwaggerGen;
  * 
  * @author Alexandre Seguin (7663995)
  */
-public class MinimalGetEndpointTest {
+public class MockMinimalGetEndpoint {
 	/**
 	 * Fake endpoint for testing purposes
 	 * @param request fake request object

--- a/swaggen/src/test/java/mock/endpoint/MockMinimalPostEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockMinimalPostEndpoint.java
@@ -1,0 +1,20 @@
+package mock.endpoint;
+import annotation.SwaggerGen;
+import mock.service.MockSlingServerletRequest;
+import mock.service.MockSlingServerletResponse;
+
+/**
+ * A Fake endpoint for testing.
+ * 
+ * @author Bill Zhang
+ */
+public class MockMinimalPostEndpoint {
+  @SwaggerGen(
+		uri="/minified-endpoint",
+		basePath="/base",
+		method="POST"
+	)
+	protected static final void doPost(MockSlingServerletRequest request, MockSlingServerletResponse resp) {
+		// Implementation not important.
+	}
+}

--- a/swaggen/src/test/java/mock/endpoint/MockMinimalPutEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockMinimalPutEndpoint.java
@@ -1,0 +1,20 @@
+package mock.endpoint;
+import annotation.SwaggerGen;
+import mock.service.MockSlingServerletRequest;
+import mock.service.MockSlingServerletResponse;
+
+/**
+ * A Fake endpoint for testing.
+ * 
+ * @author Bill Zhang
+ */
+public class MockMinimalPutEndpoint {
+  @SwaggerGen(
+		uri="/minified-endpoint",
+		basePath="base",
+		method="PUT"
+	)
+	protected static final void doPost(MockSlingServerletRequest request, MockSlingServerletResponse resp) {
+		// Implementation not important.
+	}
+}

--- a/swaggen/src/test/java/mock/endpoint/MockMinimalPutEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockMinimalPutEndpoint.java
@@ -11,10 +11,10 @@ import mock.service.MockSlingServerletResponse;
 public class MockMinimalPutEndpoint {
   @SwaggerGen(
 		uri="/minified-endpoint",
-		basePath="base",
+		basePath="/base",
 		method="PUT"
 	)
-	protected static final void doPost(MockSlingServerletRequest request, MockSlingServerletResponse resp) {
+	protected static final void doPut(MockSlingServerletRequest request, MockSlingServerletResponse resp) {
 		// Implementation not important.
 	}
 }

--- a/swaggen/src/test/java/mock/endpoint/MockNoBasePathEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockNoBasePathEndpoint.java
@@ -28,7 +28,7 @@ public class MockNoBasePathEndpoint {
 	@SwaggerGen(
 		uri="/base",
 		method="GET",
-		description="Put Servlet Description",
+		description="Get Servlet Description",
 		responses={"200=OK", "400", "404"},
 		scheme="HTTP"
   )

--- a/swaggen/src/test/java/mock/endpoint/MockNoBasePathEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockNoBasePathEndpoint.java
@@ -1,0 +1,70 @@
+package mock.endpoint;
+import annotation.SwaggerGen;
+/**
+ * Fake endpoints for testing
+ */
+public class MockNoBasePathEndpoint {
+  /**
+	 * Fake endpoint for testing purposes
+	 * @param request fake request object
+	 * @param resp fake response object
+	 */
+	@SwaggerGen(
+		uri="/base",
+		method="PUT",
+		description="Put Servlet Description",
+		responses={"200=OK", "400", "404"},
+		scheme="HTTP"
+  )
+  public void doPut(Object request, Object resp) {
+		// Implementation not important.
+  }
+  
+  /**
+	 * Fake endpoint for testing purposes
+	 * @param request fake request object
+	 * @param resp fake response object
+	 */
+	@SwaggerGen(
+		uri="/base",
+		method="GET",
+		description="Put Servlet Description",
+		responses={"200=OK", "400", "404"},
+		scheme="HTTP"
+  )
+  public void doGet(Object request, Object resp) {
+		// Implementation not important.
+  }
+  
+  /**
+	 * Fake endpoint for testing purposes
+	 * @param request fake request object
+	 * @param resp fake response object
+	 */
+	@SwaggerGen(
+		uri="/base",
+		method="POST",
+		description="Post Servlet Description",
+		responses={"200=OK", "400", "404"},
+		scheme="HTTP"
+  )
+  public void doPost(Object request, Object resp) {
+		// Implementation not important.
+  }
+  
+  /**
+	 * Fake endpoint for testing purposes
+	 * @param request fake request object
+	 * @param resp fake response object
+	 */
+	@SwaggerGen(
+		uri="/base",
+		method="DELETE",
+		description="Delete Servlet Description",
+		responses={"200=OK", "400", "404"},
+		scheme="HTTP"
+  )
+  public void doDelete(Object request, Object resp) {
+		// Implementation not important.
+  }
+}

--- a/swaggen/src/test/java/mock/endpoint/MockPostEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockPostEndpoint.java
@@ -12,7 +12,7 @@ public class MockPostEndpoint {
 
 	@SwaggerGen(
 		uri="/endpoint",
-		basePath="base",
+		basePath="/base",
 		method="POST",
 		title="Serverlet Title",
 		description="Serverlet Description",

--- a/swaggen/src/test/java/mock/endpoint/MockPostEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockPostEndpoint.java
@@ -11,7 +11,7 @@ import mock.service.MockSlingServerletResponse;
 public class MockPostEndpoint {
 
 	@SwaggerGen(
-		url="/endpoint",
+		uri="/endpoint",
 		basePath="base",
 		method="POST",
 		title="Serverlet Title",

--- a/swaggen/src/test/java/mock/endpoint/MockPostEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockPostEndpoint.java
@@ -11,7 +11,8 @@ import mock.service.MockSlingServerletResponse;
 public class MockPostEndpoint {
 
 	@SwaggerGen(
-		url="/base/endpoint",
+		url="/endpoint",
+		basePath="base",
 		method="POST",
 		title="Serverlet Title",
 		description="Serverlet Description",

--- a/swaggen/src/test/java/mock/endpoint/MockPutDeleteEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MockPutDeleteEndpoint.java
@@ -1,0 +1,32 @@
+package mock.endpoint;
+import annotation.SwaggerGen;
+import mock.service.MockSlingServerletRequest;
+import mock.service.MockSlingServerletResponse;
+
+/**
+ * A Fake endpoint for testing.
+ */
+public class MockPutDeleteEndpoint {
+
+	@SwaggerGen(
+		uri="/combined",
+		basePath="/base/all",
+		method="PUT",
+		title="Put Serverlet Title",
+		description="Put Serverlet Description"
+	)
+	protected static final void doPut(MockSlingServerletRequest request, MockSlingServerletResponse resp) {
+		// Implementation not important.
+  }
+  
+  @SwaggerGen(
+		uri="/combined",
+		basePath="/base/all",
+		method="DELETE",
+		title="Delete Serverlet Title",
+		description="Delete Serverlet Description"
+	)
+	protected static final void doDelete(MockSlingServerletRequest request, MockSlingServerletResponse resp) {
+		// Implementation not important.
+  }
+}

--- a/swaggen/src/test/java/mock/endpoint/MockPutEndpointWithSchema.java
+++ b/swaggen/src/test/java/mock/endpoint/MockPutEndpointWithSchema.java
@@ -13,7 +13,7 @@ public class MockPutEndpointWithSchema {
 	 */
 	@SwaggerGen(
 		uri="/all-methods-endpoint",
-		basePath="base",
+		basePath="/base",
 		method="PUT",
 		description="Put Servlet Description",
 		headers={"Content-Type=application/json", "langHeader=en"},

--- a/swaggen/src/test/java/mock/endpoint/MockPutEndpointWithSchema.java
+++ b/swaggen/src/test/java/mock/endpoint/MockPutEndpointWithSchema.java
@@ -12,7 +12,7 @@ public class MockPutEndpointWithSchema {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/all-methods-endpoint",
+		uri="/all-methods-endpoint",
 		basePath="base",
 		method="PUT",
 		description="Put Servlet Description",

--- a/swaggen/src/test/java/mock/endpoint/MockPutEndpointWithSchema.java
+++ b/swaggen/src/test/java/mock/endpoint/MockPutEndpointWithSchema.java
@@ -12,7 +12,8 @@ public class MockPutEndpointWithSchema {
 	 * @param resp fake response object
 	 */
 	@SwaggerGen(
-		url="/base/all-methods-endpoint",
+		url="/all-methods-endpoint",
+		basePath="base",
 		method="PUT",
 		description="Put Servlet Description",
 		headers={"Content-Type=application/json", "langHeader=en"},

--- a/swaggen/src/test/java/mock/endpoint/MockShareBasePath.java
+++ b/swaggen/src/test/java/mock/endpoint/MockShareBasePath.java
@@ -1,0 +1,74 @@
+package mock.endpoint;
+import annotation.SwaggerGen;
+/**
+ * Fake endpoints for testing
+ */
+public class MockShareBasePath {
+  /**
+	 * Fake endpoint for testing purposes
+	 * @param request fake request object
+	 * @param resp fake response object
+	 */
+	@SwaggerGen(
+		uri="/in-depth",
+		basePath="/base/endpoint",
+		method="PUT",
+		description="Put Servlet Description",
+		responses={"200=OK", "400", "404"},
+		scheme="HTTP"
+  )
+  public void doPut(Object request, Object resp) {
+		// Implementation not important.
+  }
+  
+  /**
+	 * Fake endpoint for testing purposes
+	 * @param request fake request object
+	 * @param resp fake response object
+	 */
+	@SwaggerGen(
+		uri="/in-depth",
+		basePath="/base/endpoint",
+		method="GET",
+		description="Put Servlet Description",
+		responses={"200=OK", "400", "404"},
+		scheme="HTTP"
+  )
+  public void doGet(Object request, Object resp) {
+		// Implementation not important.
+  }
+  
+  /**
+	 * Fake endpoint for testing purposes
+	 * @param request fake request object
+	 * @param resp fake response object
+	 */
+	@SwaggerGen(
+		uri="/in-depth",
+		basePath="/base/endpoint",
+		method="POST",
+		description="Post Servlet Description",
+		responses={"200=OK", "400", "404"},
+		scheme="HTTP"
+  )
+  public void doPost(Object request, Object resp) {
+		// Implementation not important.
+  }
+  
+  /**
+	 * Fake endpoint for testing purposes
+	 * @param request fake request object
+	 * @param resp fake response object
+	 */
+	@SwaggerGen(
+		uri="/in-depth",
+		basePath="/base/endpoint",
+		method="DELETE",
+		description="Delete Servlet Description",
+		responses={"200=OK", "400", "404"},
+		scheme="HTTP"
+  )
+  public void doDelete(Object request, Object resp) {
+		// Implementation not important.
+  }
+}

--- a/swaggen/src/test/java/mock/endpoint/MultiplePathsEndpoint.java
+++ b/swaggen/src/test/java/mock/endpoint/MultiplePathsEndpoint.java
@@ -1,0 +1,32 @@
+package mock.endpoint;
+import annotation.SwaggerGen;
+/**
+ * Fake endpoints for testing
+ */
+public class MultiplePathsEndpoint {
+  @SwaggerGen(
+    uri="/all-methods-endpoint",
+    basePath="/base",
+    method="GET",
+    description="Get Servlet Description",
+		headers={"Content-Type=application/json", "langHeader=en"},
+		responses={"200=OK", "400", "404"},
+		scheme="HTTP"
+  )
+  public void doGet(Object request, Object resp) {
+
+  }
+
+  @SwaggerGen(
+    uri="/endpoint",
+    basePath="/base",
+    method="PUT",
+    description="Put Servlet Description",
+    headers={"Content-Type=application/json", "langHeader=en"},
+		responses={"200=OK", "400", "404"},
+		scheme="HTTP"
+  )
+  public void doPut(Object request, Object resp) {
+
+  }
+}

--- a/swaggen/src/test/java/tests/annotation/annotationTests.java
+++ b/swaggen/src/test/java/tests/annotation/annotationTests.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import domain.output.path.Endpoint;
+import domain.output.PathURL;
 import domain.output.SwaggerEndpoint;
 import enums.ParamType;
 import enums.RequestMethod;
@@ -27,9 +28,8 @@ public class annotationTests {
 	public void testAnnotation() {
 		
 		Class<?>[] klasses = {MockPostEndpoint.class};
-		Map<String, SwaggerEndpoint> path = generator.PathGenerator.generatePathsFromClassList(klasses);
-	
-		Endpoint endpoint = path.get("/base/endpoint").getEndpoint(RequestMethod.POST);
+		Map<PathURL, SwaggerEndpoint> path = generator.PathGenerator.generatePathsFromClassList(klasses);
+		Endpoint endpoint = path.get(path.keySet().toArray()[0]).getEndpoint(RequestMethod.POST);
 		
 		assertEquals(endpoint.getDescription(), "Serverlet Description");
 		assertEquals(endpoint.getSummary(), "Serverlet Title");

--- a/swaggen/src/test/java/tests/annotation/annotationTests.java
+++ b/swaggen/src/test/java/tests/annotation/annotationTests.java
@@ -3,14 +3,17 @@ package tests.annotation;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
+import java.util.List;
 
 import org.junit.Test;
 
 import domain.output.path.Endpoint;
+import domain.output.SwaggerEndpoint;
 import enums.ParamType;
 import enums.RequestMethod;
 import generator.PathGenerator;
 import mock.endpoint.MockPostEndpoint;
+
 
 /**
  * Tests the annotation
@@ -26,9 +29,15 @@ public class annotationTests {
 	public void testAnnotation() {
 		
 		Class<?>[] klasses = {MockPostEndpoint.class};
-		Map<String, Map<RequestMethod, Endpoint>> path = PathGenerator.generatePathsFromClassList(klasses);
+		Map<String, List<SwaggerEndpoint>> path = generator.PathGenerator.generatePathsFromClassList(klasses);
 		
-		Endpoint endpoint = path.get("base/endpoint").get(RequestMethod.POST);
+		Endpoint endpoint = null;
+
+		for (SwaggerEndpoint Swagger: path.get("base/endpoint")) {
+			if (Swagger.getEndpoint(RequestMethod.POST) != null) {
+				endpoint = Swagger.getEndpoint(RequestMethod.POST);
+			}
+		}
 		
 		assertEquals(endpoint.getDescription(), "Serverlet Description");
 		assertEquals(endpoint.getSummary(), "Serverlet Title");

--- a/swaggen/src/test/java/tests/annotation/annotationTests.java
+++ b/swaggen/src/test/java/tests/annotation/annotationTests.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import domain.output.path.Endpoint;
-import domain.output.PathURL;
+import domain.output.PathUri;
 import domain.output.SwaggerEndpoint;
 import enums.ParamType;
 import enums.RequestMethod;
@@ -28,7 +28,7 @@ public class annotationTests {
 	public void testAnnotation() {
 		
 		Class<?>[] klasses = {MockPostEndpoint.class};
-		Map<PathURL, SwaggerEndpoint> path = generator.PathGenerator.generatePathsFromClassList(klasses);
+		Map<PathUri, SwaggerEndpoint> path = generator.PathGenerator.generatePathsFromClassList(klasses);
 		Endpoint endpoint = path.get(path.keySet().toArray()[0]).getEndpoint(RequestMethod.POST);
 		
 		assertEquals(endpoint.getDescription(), "Serverlet Description");

--- a/swaggen/src/test/java/tests/annotation/annotationTests.java
+++ b/swaggen/src/test/java/tests/annotation/annotationTests.java
@@ -28,7 +28,7 @@ public class annotationTests {
 		Class<?>[] klasses = {MockPostEndpoint.class};
 		Map<String, Map<RequestMethod, Endpoint>> path = PathGenerator.generatePathsFromClassList(klasses);
 		
-		Endpoint endpoint = path.get("/base/endpoint").get(RequestMethod.POST);
+		Endpoint endpoint = path.get("base/endpoint").get(RequestMethod.POST);
 		
 		assertEquals(endpoint.getDescription(), "Serverlet Description");
 		assertEquals(endpoint.getSummary(), "Serverlet Title");

--- a/swaggen/src/test/java/tests/annotation/annotationTests.java
+++ b/swaggen/src/test/java/tests/annotation/annotationTests.java
@@ -3,7 +3,6 @@ package tests.annotation;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
-import java.util.List;
 
 import org.junit.Test;
 
@@ -11,7 +10,6 @@ import domain.output.path.Endpoint;
 import domain.output.SwaggerEndpoint;
 import enums.ParamType;
 import enums.RequestMethod;
-import generator.PathGenerator;
 import mock.endpoint.MockPostEndpoint;
 
 
@@ -29,15 +27,9 @@ public class annotationTests {
 	public void testAnnotation() {
 		
 		Class<?>[] klasses = {MockPostEndpoint.class};
-		Map<String, List<SwaggerEndpoint>> path = generator.PathGenerator.generatePathsFromClassList(klasses);
-		
-		Endpoint endpoint = null;
-
-		for (SwaggerEndpoint Swagger: path.get("base/endpoint")) {
-			if (Swagger.getEndpoint(RequestMethod.POST) != null) {
-				endpoint = Swagger.getEndpoint(RequestMethod.POST);
-			}
-		}
+		Map<String, SwaggerEndpoint> path = generator.PathGenerator.generatePathsFromClassList(klasses);
+	
+		Endpoint endpoint = path.get("/base/endpoint").getEndpoint(RequestMethod.POST);
 		
 		assertEquals(endpoint.getDescription(), "Serverlet Description");
 		assertEquals(endpoint.getSummary(), "Serverlet Title");

--- a/swaggen/src/test/java/tests/swagger/EndToEndTests.java
+++ b/swaggen/src/test/java/tests/swagger/EndToEndTests.java
@@ -2,7 +2,7 @@ package tests.swagger;
 
 import org.junit.Test;
 
-import mock.endpoint.MinimalGetEndpointTest;
+import mock.endpoint.MockMinimalGetEndpoint;
 import mock.endpoint.MockAllMethodsEndpoint;
 import mock.endpoint.MockGetPostEndpoint;
 import mock.endpoint.MockMinimalPostEndpoint;
@@ -59,12 +59,12 @@ public class EndToEndTests {
 	}
 
 	/**
-	 * Test to generate a Swagger file using the MinimalGetEndpointTest mock endpoint.
+	 * Test to generate a Swagger file using the MockMinimalGetEndpointTest mock endpoint.
 	 */
 	@Test
 	public void MinimalEndpointTest() {
 		try {
-			TestSwaggerGenerator.generateSwagger(MinimalGetEndpointTest.class);
+			TestSwaggerGenerator.generateSwagger(MockMinimalGetEndpoint.class);
 		} catch (Exception e) {
 			e.printStackTrace();
 			assert(false);
@@ -78,7 +78,7 @@ public class EndToEndTests {
 	public void MultipleFileEndpointTest() {
 		try {
 			TestSwaggerGenerator.generateSwagger(new Class<?>[]{MockMinimalPutEndpoint.class, 
-				MockMinimalPostEndpoint.class, MinimalGetEndpointTest.class});
+				MockMinimalPostEndpoint.class, MockMinimalGetEndpoint.class});
 		} catch (Exception e) {
 			e.printStackTrace();
 			assert(false);
@@ -92,7 +92,7 @@ public class EndToEndTests {
 	public void MultipleClassesEndpointTest() {
 		try {
 			TestSwaggerGenerator.generateSwagger(new Class<?>[]{MockMinimalPutEndpoint.class, 
-				MockPutEndpointWithSchema.class, MockMinimalPostEndpoint.class, MinimalGetEndpointTest.class,
+				MockPutEndpointWithSchema.class, MockMinimalPostEndpoint.class, MockMinimalGetEndpoint.class,
 				MockAllMethodsEndpoint.class, MockPostEndpoint.class});
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/swaggen/src/test/java/tests/swagger/EndToEndTests.java
+++ b/swaggen/src/test/java/tests/swagger/EndToEndTests.java
@@ -8,6 +8,7 @@ import mock.endpoint.MockMinimalPostEndpoint;
 import mock.endpoint.MockPostEndpoint;
 import mock.endpoint.MockMinimalPutEndpoint;
 import mock.endpoint.MockPutEndpointWithSchema;
+import mock.endpoint.MultiplePathsEndpoint;
 
 public class EndToEndTests {
 
@@ -72,7 +73,7 @@ public class EndToEndTests {
 	@Test
 	public void MultipleFileEndpointTest() {
 		try {
-			TestSwaggerGenerator.generateSwaggerClasses(new Class<?>[]{MockMinimalPutEndpoint.class, 
+			TestSwaggerGenerator.generateSwagger(new Class<?>[]{MockMinimalPutEndpoint.class, 
 				MockMinimalPostEndpoint.class, MinimalGetEndpointTest.class});
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -86,9 +87,22 @@ public class EndToEndTests {
 	@Test
 	public void MultipleClassesEndpointTest() {
 		try {
-			TestSwaggerGenerator.generateSwaggerClasses(new Class<?>[]{MockMinimalPutEndpoint.class, 
+			TestSwaggerGenerator.generateSwagger(new Class<?>[]{MockMinimalPutEndpoint.class, 
 				MockPutEndpointWithSchema.class, MockMinimalPostEndpoint.class, MinimalGetEndpointTest.class,
 				MockAllMethodsEndpoint.class, MockPostEndpoint.class});
+		} catch (Exception e) {
+			e.printStackTrace();
+			assert(false);
+		}
+	}
+
+	/**
+	 * Test to generate different paths from the same class
+	 */
+	@Test
+	public void MultiplePathsEndpointTest() {
+		try {
+			TestSwaggerGenerator.generateSwagger(new Class<?>[]{MultiplePathsEndpoint.class});
 		} catch (Exception e) {
 			e.printStackTrace();
 			assert(false);

--- a/swaggen/src/test/java/tests/swagger/EndToEndTests.java
+++ b/swaggen/src/test/java/tests/swagger/EndToEndTests.java
@@ -72,8 +72,23 @@ public class EndToEndTests {
 	@Test
 	public void MultipleFileEndpointTest() {
 		try {
-			TestSwaggerGenerator.generateSwagger(MockMinimalPutEndpoint.class);
-			TestSwaggerGenerator.generateSwagger(MockMinimalPostEndpoint.class);
+			TestSwaggerGenerator.generateSwaggerClasses(new Class<?>[]{MockMinimalPutEndpoint.class, 
+				MockMinimalPostEndpoint.class, MinimalGetEndpointTest.class});
+		} catch (Exception e) {
+			e.printStackTrace();
+			assert(false);
+		}
+	}
+
+	/**
+	 * Test to generate Swagger file with more than one class
+	 */
+	@Test
+	public void MultipleClassesEndpointTest() {
+		try {
+			TestSwaggerGenerator.generateSwaggerClasses(new Class<?>[]{MockMinimalPutEndpoint.class, 
+				MockPutEndpointWithSchema.class, MockMinimalPostEndpoint.class, MinimalGetEndpointTest.class,
+				MockAllMethodsEndpoint.class, MockPostEndpoint.class});
 		} catch (Exception e) {
 			e.printStackTrace();
 			assert(false);

--- a/swaggen/src/test/java/tests/swagger/EndToEndTests.java
+++ b/swaggen/src/test/java/tests/swagger/EndToEndTests.java
@@ -4,11 +4,15 @@ import org.junit.Test;
 
 import mock.endpoint.MinimalGetEndpointTest;
 import mock.endpoint.MockAllMethodsEndpoint;
+import mock.endpoint.MockGetPostEndpoint;
 import mock.endpoint.MockMinimalPostEndpoint;
 import mock.endpoint.MockPostEndpoint;
 import mock.endpoint.MockMinimalPutEndpoint;
 import mock.endpoint.MockPutEndpointWithSchema;
+import mock.endpoint.MockShareBasePath;
 import mock.endpoint.MultiplePathsEndpoint;
+import mock.endpoint.MockNoBasePathEndpoint;
+import mock.endpoint.MockPutDeleteEndpoint;
 
 public class EndToEndTests {
 
@@ -102,7 +106,59 @@ public class EndToEndTests {
 	@Test
 	public void MultiplePathsEndpointTest() {
 		try {
-			TestSwaggerGenerator.generateSwagger(new Class<?>[]{MultiplePathsEndpoint.class});
+			TestSwaggerGenerator.generateSwagger(MultiplePathsEndpoint.class);
+		} catch (Exception e) {
+			e.printStackTrace();
+			assert(false);
+		}
+	}
+	/**
+	 * Test to generate endpoints that share base paths
+	 */
+	@Test
+	public void ShareBasePathsTest() {
+		try {
+			TestSwaggerGenerator.generateSwagger(new Class<?>[]{MockShareBasePath.class, MockPostEndpoint.class});
+		} catch (Exception e) {
+			e.printStackTrace();
+			assert(false);
+		}
+	}
+
+	/**
+	 * Test to generate endpoint that have no base path
+	 */
+	@Test
+	public void NoBasePathsTest() {
+		try {
+			TestSwaggerGenerator.generateSwagger(MockNoBasePathEndpoint.class);
+		} catch (Exception e) {
+			e.printStackTrace();
+			assert(false);
+		}
+	}
+
+	/**
+	 * Test to generate multiple request methods from different classes
+	 */
+	@Test
+	public void combineDifferentClasses() {
+		try {
+			TestSwaggerGenerator.generateSwagger(new Class<?>[]{MockGetPostEndpoint.class, MockPutDeleteEndpoint.class});
+		} catch (Exception e) {
+			e.printStackTrace();
+			assert(false);
+		}
+	}
+
+	/**
+	 * Test to generate an endpoint that is already generated
+	 */
+	@Test
+	public void AlreadyGeneratedEndpointTest() {
+		try {
+			TestSwaggerGenerator.generateSwagger(MockPostEndpoint.class);
+			TestSwaggerGenerator.generateSwagger(MockPostEndpoint.class);
 		} catch (Exception e) {
 			e.printStackTrace();
 			assert(false);

--- a/swaggen/src/test/java/tests/swagger/EndToEndTests.java
+++ b/swaggen/src/test/java/tests/swagger/EndToEndTests.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import mock.endpoint.MinimalGetEndpointTest;
 import mock.endpoint.MockAllMethodsEndpoint;
 import mock.endpoint.MockPostEndpoint;
+import mock.endpoint.MockMinimalPutEndpoint;
 import mock.endpoint.MockPutEndpointWithSchema;
 
 public class EndToEndTests {
@@ -63,7 +64,20 @@ public class EndToEndTests {
 			assert(false);
 		}
 	}
-	
+
+	/**
+	 * Test to generate Swagger file in same folder from different classes.
+	 */
+ 
+	@Test
+	public void MinimalPutEndpointTest() {
+		try {
+			TestSwaggerGenerator.generateSwagger("generated/swagger/MinimalYaml.yaml", MockMinimalPutEndpoint.class);
+		} catch (Exception e) {
+			e.printStackTrace();
+			assert(false);
+		}
+	}
 	
 
 }

--- a/swaggen/src/test/java/tests/swagger/EndToEndTests.java
+++ b/swaggen/src/test/java/tests/swagger/EndToEndTests.java
@@ -152,7 +152,8 @@ public class EndToEndTests {
 	}
 
 	/**
-	 * Test to generate an endpoint that is already generated
+	 * Test to generate an endpoint that is already generated to see if there is 
+	 * duplication
 	 */
 	@Test
 	public void AlreadyGeneratedEndpointTest() {

--- a/swaggen/src/test/java/tests/swagger/EndToEndTests.java
+++ b/swaggen/src/test/java/tests/swagger/EndToEndTests.java
@@ -99,19 +99,6 @@ public class EndToEndTests {
 			assert(false);
 		}
 	}
-
-	/**
-	 * Test to generate different paths from the same class
-	 */
-	@Test
-	public void MultiplePathsEndpointTest() {
-		try {
-			TestSwaggerGenerator.generateSwagger(MultiplePathsEndpoint.class);
-		} catch (Exception e) {
-			e.printStackTrace();
-			assert(false);
-		}
-	}
 	/**
 	 * Test to generate endpoints that share base paths
 	 */
@@ -124,7 +111,6 @@ public class EndToEndTests {
 			assert(false);
 		}
 	}
-
 	/**
 	 * Test to generate endpoint that have no base path
 	 */
@@ -160,6 +146,18 @@ public class EndToEndTests {
 		try {
 			TestSwaggerGenerator.generateSwagger(MockPostEndpoint.class);
 			TestSwaggerGenerator.generateSwagger(MockPostEndpoint.class);
+		} catch (Exception e) {
+			e.printStackTrace();
+			assert(false);
+		}
+	}
+	/**
+	 * Test to generate different paths from the same class
+	 */
+	@Test
+	public void MultiplePathsEndpointTest() {
+		try {
+			TestSwaggerGenerator.generateSwagger(new Class<?>[]{MultiplePathsEndpoint.class, MockPostEndpoint.class});
 		} catch (Exception e) {
 			e.printStackTrace();
 			assert(false);

--- a/swaggen/src/test/java/tests/swagger/EndToEndTests.java
+++ b/swaggen/src/test/java/tests/swagger/EndToEndTests.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import mock.endpoint.MinimalGetEndpointTest;
 import mock.endpoint.MockAllMethodsEndpoint;
+import mock.endpoint.MockMinimalPostEndpoint;
 import mock.endpoint.MockPostEndpoint;
 import mock.endpoint.MockMinimalPutEndpoint;
 import mock.endpoint.MockPutEndpointWithSchema;
@@ -17,7 +18,7 @@ public class EndToEndTests {
 	@Test
 	public void AllMethodsEndpointTest() {
 		try {
-			TestSwaggerGenerator.generateSwagger("generated/swagger/AllMethodsEndpointYaml.yaml", MockAllMethodsEndpoint.class);
+			TestSwaggerGenerator.generateSwagger(MockAllMethodsEndpoint.class);
 		} catch (Exception e) {
 			e.printStackTrace();
 			assert(false);
@@ -31,7 +32,7 @@ public class EndToEndTests {
 	@Test
 	public void PostEndpointTest() {
 		try {
-			TestSwaggerGenerator.generateSwagger("generated/swagger/PostEndpointYaml.yaml", MockPostEndpoint.class);
+			TestSwaggerGenerator.generateSwagger(MockPostEndpoint.class);
 		} catch (Exception e) {
 			e.printStackTrace();
 			assert(false);
@@ -45,7 +46,7 @@ public class EndToEndTests {
 	@Test
 	public void PutEndpointTest() {
 		try {
-			TestSwaggerGenerator.generateSwagger("generated/swagger/PutEndpointYaml.yaml", MockPutEndpointWithSchema.class);
+			TestSwaggerGenerator.generateSwagger(MockPutEndpointWithSchema.class);
 		} catch (Exception e) {
 			e.printStackTrace();
 			assert(false);
@@ -58,7 +59,7 @@ public class EndToEndTests {
 	@Test
 	public void MinimalEndpointTest() {
 		try {
-			TestSwaggerGenerator.generateSwagger("generated/swagger/MinimalYaml.yaml", MinimalGetEndpointTest.class);
+			TestSwaggerGenerator.generateSwagger(MinimalGetEndpointTest.class);
 		} catch (Exception e) {
 			e.printStackTrace();
 			assert(false);
@@ -68,16 +69,14 @@ public class EndToEndTests {
 	/**
 	 * Test to generate Swagger file in same folder from different classes.
 	 */
- 
 	@Test
-	public void MinimalPutEndpointTest() {
+	public void MultipleFileEndpointTest() {
 		try {
-			TestSwaggerGenerator.generateSwagger("generated/swagger/MinimalYaml.yaml", MockMinimalPutEndpoint.class);
+			TestSwaggerGenerator.generateSwagger(MockMinimalPutEndpoint.class);
+			TestSwaggerGenerator.generateSwagger(MockMinimalPostEndpoint.class);
 		} catch (Exception e) {
 			e.printStackTrace();
 			assert(false);
 		}
 	}
-	
-
 }

--- a/swaggen/src/test/java/tests/swagger/TestSwaggerGenerator.java
+++ b/swaggen/src/test/java/tests/swagger/TestSwaggerGenerator.java
@@ -19,9 +19,9 @@ public class TestSwaggerGenerator {
 	 * @throws JsonMappingException
 	 * @throws IOException
 	 */
-	public static void generateSwagger(String filelocation, Class<?> klass)
+	public static void generateSwagger(Class<?> klass)
 			throws JsonParseException, JsonMappingException, IOException {
-		SwaggerGenerator.generateSwaggerFile(new Class<?>[] { klass }, filelocation);
+		SwaggerGenerator.generateSwaggerFile(new Class<?>[] { klass });
 	}
 
 

--- a/swaggen/src/test/java/tests/swagger/TestSwaggerGenerator.java
+++ b/swaggen/src/test/java/tests/swagger/TestSwaggerGenerator.java
@@ -34,7 +34,7 @@ public class TestSwaggerGenerator {
 	 * @throws JsonMappingException
 	 * @throws IOException
 	 */
-	public static void generateSwaggerClasses(Class<?>[] klasses) 
+	public static void generateSwagger(Class<?>[] klasses) 
 		throws JsonParseException, JsonMappingException, IOException {
 		SwaggerGenerator.generateSwaggerFile(klasses);
 	}

--- a/swaggen/src/test/java/tests/swagger/TestSwaggerGenerator.java
+++ b/swaggen/src/test/java/tests/swagger/TestSwaggerGenerator.java
@@ -24,5 +24,19 @@ public class TestSwaggerGenerator {
 		SwaggerGenerator.generateSwaggerFile(new Class<?>[] { klass });
 	}
 
+	/**
+	 * Function that calls the Swagger generation flow and eventually writes the
+	 * swagger file for the endpoint passed in to the location passed in.
+	 * 
+	 * @param filelocation location of the swagger file to be generated
+	 * @param klass class representing the test endpoint
+	 * @throws JsonParseException
+	 * @throws JsonMappingException
+	 * @throws IOException
+	 */
+	public static void generateSwaggerClasses(Class<?>[] klasses) 
+		throws JsonParseException, JsonMappingException, IOException {
+		SwaggerGenerator.generateSwaggerFile(klasses);
+	}
 
 }

--- a/swaggen/src/test/java/tests/yaml/YamlFileWriterTest.java
+++ b/swaggen/src/test/java/tests/yaml/YamlFileWriterTest.java
@@ -30,7 +30,7 @@ public class YamlFileWriterTest {
 	 * @throws JsonMappingException
 	 * @throws IOException
 	 */
-	@Test
+	//@Test
 	public void testYamlWriter() throws JsonGenerationException, JsonMappingException, IOException {
 		String filename = "test/generated/testYamlWriter.yaml";
 		MockYamlBase mockYamlBase = MockYamlFactory.getMockYaml();

--- a/swaggen/src/test/java/tests/yaml/YamlFileWriterTest.java
+++ b/swaggen/src/test/java/tests/yaml/YamlFileWriterTest.java
@@ -30,7 +30,7 @@ public class YamlFileWriterTest {
 	 * @throws JsonMappingException
 	 * @throws IOException
 	 */
-	//@Test
+	@Test
 	public void testYamlWriter() throws JsonGenerationException, JsonMappingException, IOException {
 		String filename = "test/generated/testYamlWriter.yaml";
 		MockYamlBase mockYamlBase = MockYamlFactory.getMockYaml();


### PR DESCRIPTION
## Purpose
Based on the base path and uri listed in the endpoint's SwaggerGen annotation, there will be a folder(s) created for the endpoint and the yaml file, that is valid swagger, will be there.

In addition, there is now a new ruby script called `generate_docs` that creates the html files from the yaml files and places them in `swaggen_html` if the yaml comes from swaggen, or `sample-project_html` if the yaml comes from sample-project

Created a new class called SwaggerEndpoint that contains the map of request methods to endpoints, but created to potentially contain more.

Example folder structure:
![image](https://user-images.githubusercontent.com/21375588/60908697-838f5880-a24a-11e9-91c7-bf80d22dd8ea.png)

Sample yaml file from changes:
![image](https://user-images.githubusercontent.com/21375588/60909027-32cc2f80-a24b-11e9-956d-c05cd44c207c.png)

Sample redoc file from changes:
![image](https://user-images.githubusercontent.com/21375588/60909111-6c049f80-a24b-11e9-8e5b-a7ec94f92d39.png)


