### PR TITLE
feat(#86): Add default status code descriptions.

### DIFF
--- a/swaggen/pom.xml
+++ b/swaggen/pom.xml
@@ -160,6 +160,19 @@
 			<artifactId>plexus-utils</artifactId>
 			<version>3.0.15</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/commons-httpclient/commons-httpclient -->
+		<dependency>
+		    <groupId>commons-httpclient</groupId>
+		    <artifactId>commons-httpclient</artifactId>
+		    <version>3.1</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
+		<dependency>
+		    <groupId>org.mockito</groupId>
+		    <artifactId>mockito-all</artifactId>
+		    <version>1.9.5</version>
+		    <scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/swaggen/src/main/java/factory/ResponseFactory.java
+++ b/swaggen/src/main/java/factory/ResponseFactory.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.httpclient.HttpStatus;
+
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
@@ -11,32 +13,18 @@ import annotation.SwaggerGen;
 import annotation.SwaggerResponse;
 import domain.output.path.Response;
 
+
 /**
  * Creates a response from the annotation
  * 
  * @author William Gardiner (7267012)
  */
 public class ResponseFactory {
-
-    /**
-     * The delimiter between response codes and their description
-     */
-    private static final String DELIMITER = "=";
-    
-    /**
-     * The index of the response code
-     */
-    private static final int CODE_INDEX = 0;
-    
-    /**
-     * The index of the description
-     */
-    private static final int DESCRIPTION_INDEX = 1;
     
     /**
      * The description when no description id provided
      */
-    private static final String DEFAULT_DESCRIPTION = "No description";
+    public static final String DEFAULT_DESCRIPTION = "No description";
     
     /**
      * Generates a Map of response codes to Responses from the annotation
@@ -55,7 +43,8 @@ public class ResponseFactory {
             if(responseAnnotation.description() != null) {
                 response.setDescription(responseAnnotation.description());
             } else {
-                response.setDescription(DEFAULT_DESCRIPTION);
+            	String defaultStatusText = HttpStatus.getStatusText(responseAnnotation.code());
+                response.setDescription(defaultStatusText != null ? defaultStatusText : DEFAULT_DESCRIPTION);
             }
             
             String code = String.valueOf(responseAnnotation.code());

--- a/swaggen/src/test/java/tests/factory/response/ResponseFactoryTest.java
+++ b/swaggen/src/test/java/tests/factory/response/ResponseFactoryTest.java
@@ -1,0 +1,74 @@
+package tests.factory.response;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.commons.httpclient.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+
+import annotation.SwaggerGen;
+import annotation.SwaggerResponse;
+import annotation.body.SwaggerBody;
+import domain.output.path.Response;
+import factory.ResponseFactory;
+
+public class ResponseFactoryTest {
+
+	private static final String DESCRIPTION = "fooDescription";
+	private static final int RESPONSE_CODE = 404;
+	private static final int UNKNOWN_CODE = 1776;
+
+	SwaggerGen swaggerGen;
+	SwaggerResponse swaggerResponse;
+	SwaggerBody swaggerBody;
+	
+	@Before
+	public void beforeEach() {
+		swaggerGen = mock(SwaggerGen.class);
+		swaggerResponse = mock(SwaggerResponse.class);
+		swaggerBody = mock(SwaggerBody.class);
+		when(swaggerGen.responses()).thenReturn(new SwaggerResponse[] {swaggerResponse});
+		when(swaggerResponse.code()).thenReturn(RESPONSE_CODE);
+		when(swaggerResponse.body()).thenReturn(swaggerBody);
+		when(swaggerBody.value()).thenReturn("");
+	}
+	
+	@Test
+	public void givenDescription_whenCreateResponse_thenResponseHasDescription() throws Exception {
+		// Arrange
+		when(swaggerResponse.description()).thenReturn(DESCRIPTION);
+		
+		// Act
+		Response result = ResponseFactory.createResponses(swaggerGen).get(Integer.toString(RESPONSE_CODE));
+		
+		// Assert
+		assertEquals(DESCRIPTION, result.getDescription());
+	}
+
+	@Test
+	public void givenNoDescription_whenCreateResponse_thenResponseHasCodeDefaultDescription() throws Exception {
+		// Arrange
+		when(swaggerResponse.description()).thenReturn(null);
+		
+		// Act
+		Response result = ResponseFactory.createResponses(swaggerGen).get(Integer.toString(RESPONSE_CODE));
+		
+		// Assert
+		assertEquals(HttpStatus.getStatusText(RESPONSE_CODE), result.getDescription());
+	}
+
+	@Test
+	public void givenUnkonwnCode_whenCreateResponse_thenResponseHasDefaultDescription() throws Exception {
+		// Arrange
+		when(swaggerResponse.code()).thenReturn(UNKNOWN_CODE);
+		when(swaggerResponse.description()).thenReturn(null);
+		
+		// Act
+		Response result = ResponseFactory.createResponses(swaggerGen).get(Integer.toString(UNKNOWN_CODE));
+		
+		// Assert
+		assertEquals(ResponseFactory.DEFAULT_DESCRIPTION, result.getDescription());
+	}
+}


### PR DESCRIPTION
## Purpose
Added default descriptions when none is provided.
Left default "no Description" message when code is not in RFC1945(HTTP/1.0), RFC2616 (HTTP/1.1), nor RFC2518 (WebDAV).
Added Mockito for testing. Makes testing annotations easie

## Acceptance Criteria
- [ ] Default description based on code appears when no description is provided.
